### PR TITLE
Benchmark the solver in wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+node_modules
+package.json
+package-lock.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,11 @@ dependencies = [
 name = "ezpz-wasm"
 version = "0.1.0"
 dependencies = [
+ "faer",
  "kcl-ezpz",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1420,6 +1422,16 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "mint"
@@ -2671,6 +2683,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/ezpz-wasm/Cargo.toml
+++ b/ezpz-wasm/Cargo.toml
@@ -8,6 +8,8 @@ crate-type = ["cdylib"]
 bench = false
 
 [dependencies]
+faer = "0.22.6"
 kcl-ezpz = { path = "../kcl-ezpz" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.50"
+wasm-bindgen-test = "0.3.50"

--- a/ezpz-wasm/main.js
+++ b/ezpz-wasm/main.js
@@ -1,6 +1,16 @@
-import init, { hello } from "./pkg/ezpz_wasm.js";
+import init, { hello, benchmark, test_faer } from "./pkg/ezpz_wasm.js";
 init().then(() => {
   console.log("Hello! Code is running.");
   const messageDisplay = document.getElementById("message");
-  messageDisplay.textContent=hello();
+  console.log("Calling test_faer");
+  messageDisplay.textContent=test_faer();
+
+  console.log("Calling benchmark");
+  const startTime = performance.now()
+  const runs=100;
+  for (let i = 0; i < runs; i++) {
+    benchmark();
+  }
+  const endTime = performance.now()
+  console.log(`Call to 'benchmark' took ${(endTime - startTime)/runs} milliseconds each (ran ${runs} times)`)
 });

--- a/ezpz-wasm/src/lib.rs
+++ b/ezpz-wasm/src/lib.rs
@@ -1,6 +1,92 @@
+use kcl_ezpz::{
+    Constraint, IdGenerator,
+    datatypes::{DatumPoint, LineSegment},
+    solve,
+};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn hello() -> i32 {
     33
+}
+
+#[wasm_bindgen]
+pub fn test_faer() -> f64 {
+    use faer::mat;
+
+    let a = mat![
+        [1.0, 5.0, 9.0], //
+        [2.0, 6.0, 10.0],
+        [3.0, 7.0, 11.0],
+        [4.0, 8.0, 12.0f64],
+    ];
+
+    a[(0, 0)]
+}
+
+#[wasm_bindgen]
+pub fn benchmark() -> Vec<f64> {
+    let mut id_generator = IdGenerator::default();
+    let p0 = DatumPoint::new(&mut id_generator);
+    let p1 = DatumPoint::new(&mut id_generator);
+    let p2 = DatumPoint::new(&mut id_generator);
+    let p3 = DatumPoint::new(&mut id_generator);
+    let line0_bottom = LineSegment::new(p0, p1, &mut id_generator);
+    let line0_right = LineSegment::new(p1, p2, &mut id_generator);
+    let line0_top = LineSegment::new(p2, p3, &mut id_generator);
+    let line0_left = LineSegment::new(p3, p0, &mut id_generator);
+    // Second square (upper case IDs)
+    let p5 = DatumPoint::new(&mut id_generator);
+    let p6 = DatumPoint::new(&mut id_generator);
+    let p7 = DatumPoint::new(&mut id_generator);
+    let line1_bottom = LineSegment::new(p2, p5, &mut id_generator);
+    let line1_right = LineSegment::new(p5, p6, &mut id_generator);
+    let line1_top = LineSegment::new(p6, p7, &mut id_generator);
+    let line1_left = LineSegment::new(p7, p2, &mut id_generator);
+    // First square (lower case IDs)
+    let constraints0 = vec![
+        Constraint::Fixed(p0.id_x(), 1.0),
+        Constraint::Fixed(p0.id_y(), 1.0),
+        Constraint::Horizontal(line0_bottom),
+        Constraint::Horizontal(line0_top),
+        Constraint::Vertical(line0_left),
+        Constraint::Vertical(line0_right),
+        Constraint::Distance(p0, p1, 4.0),
+        Constraint::Distance(p0, p3, 3.0),
+    ];
+
+    // Start p at the origin, and q at (1,9)
+    let initial_guesses = vec![
+        // First square.
+        (p0.id_x(), 1.0),
+        (p0.id_y(), 1.0),
+        (p1.id_x(), 4.5),
+        (p1.id_y(), 1.5),
+        (p2.id_x(), 4.0),
+        (p2.id_y(), 3.5),
+        (p3.id_x(), 1.5),
+        (p3.id_y(), 3.0),
+        // Second square.
+        (p5.id_x(), 5.5),
+        (p5.id_y(), 3.5),
+        (p6.id_x(), 5.0),
+        (p6.id_y(), 4.5),
+        (p7.id_x(), 2.5),
+        (p7.id_y(), 4.0),
+    ];
+
+    let constraints1 = vec![
+        Constraint::Horizontal(line1_bottom),
+        Constraint::Horizontal(line1_top),
+        Constraint::Vertical(line1_left),
+        Constraint::Vertical(line1_right),
+        Constraint::Distance(p2, p5, 4.0),
+        Constraint::Distance(p2, p7, 4.0),
+    ];
+
+    let mut constraints = constraints0;
+    constraints.extend(constraints1);
+    let actual = solve(constraints.clone(), initial_guesses.clone()).unwrap();
+    actual.final_values
+    // vec![]
 }


### PR DESCRIPTION
To build the WASM library, run

```
wasm-pack build --target web
```

This updates the ezpz playground to run the "two dependent rectangles" benchmark 100 times and measure the runtime. It clocks in at 315us in Chrome via WASM, and 83us on my Macbook. That means WASM is only 3.75x slower than native code for this -- I think that's actually pretty incredible. 3,174 solves per second means is well above our 60 solves per second goal.

This also proves you can compile and run ezpz in the browser, which is great as Faer doesn't officially advertise that compatibility as a feature.