### PR TITLE
Text representation for constraint systems + CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ezpz-cli"
+version = "0.1.0"
+dependencies = [
+ "kcl-ezpz",
+]
+
+[[package]]
 name = "ezpz-wasm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "libm",
  "newton_faer",
  "thiserror 2.0.16",
+ "winnow",
 ]
 
 [[package]]
@@ -2991,6 +2992,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "ezpz-cli",'ezpz-wasm', 'kcl-ezpz']
+members = ["ezpz-cli", 'ezpz-wasm', 'kcl-ezpz']
 resolver = "3"
 
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ['ezpz-wasm', 'kcl-ezpz']
+members = [ "ezpz-cli",'ezpz-wasm', 'kcl-ezpz']
 resolver = "3"
 
 [profile.dev.package]

--- a/ezpz-cli/Cargo.toml
+++ b/ezpz-cli/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ezpz-cli"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+kcl-ezpz = { path = "../kcl-ezpz" }

--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -1,0 +1,80 @@
+use std::{
+    hint::black_box,
+    io::{self, Read},
+    time::Duration,
+};
+
+use kcl_ezpz::textual::{Outcome, Problem};
+
+const NUM_ITERS_BENCHMARK: u32 = 100;
+
+fn main() {
+    if let Err(e) = main_inner().map(print_output) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn main_inner() -> Result<(Outcome, Duration), String> {
+    let constraint_txt = read_problem()?;
+    let parsed = Problem::parse(&mut constraint_txt.as_str()).map_err(|e| e.to_string())?;
+
+    // Ensure problem can be solved
+    let now = std::time::Instant::now();
+    let solved = parsed.solve().map_err(|e| e.to_string())?;
+
+    // It succeeded. Benchmark its perf
+    for _ in 0..NUM_ITERS_BENCHMARK {
+        let _ = black_box(parsed.solve());
+    }
+    let elapsed = now.elapsed();
+    let duration_per_iter = elapsed / NUM_ITERS_BENCHMARK;
+    Ok((solved, duration_per_iter))
+}
+
+/// Prints the output nicely to stdout.
+fn print_output((outcome, duration): (Outcome, Duration)) {
+    let Outcome {
+        iterations,
+        lints,
+        points,
+        num_vars,
+        num_eqs,
+    } = outcome;
+    if !lints.is_empty() {
+        println!("Lints:");
+        for lint in lints {
+            println!("\t{}", lint.content);
+        }
+    }
+    println!("Problem size: {num_eqs} rows, {num_vars} vars");
+    println!("Iterations needed: {iterations}");
+    println!(
+        "Solved in {}us (mean over {NUM_ITERS_BENCHMARK} iterations)",
+        duration.as_micros()
+    );
+    println!("Points:");
+    for point in points {
+        println!("\t{}: ({}, {})", point.0, point.1.x, point.1.y);
+    }
+}
+
+/// Read the EZPZ problem text from a file or stdin, depending on user args.
+/// They pass a filename, or '-' for stdin, as the first CLI arg.
+fn read_problem() -> Result<String, String> {
+    let mut args = std::env::args();
+    let _this_program = args.next().unwrap();
+    let dst = args
+        .next()
+        .ok_or("usage: first arg must be a path to an EZPZ problem text file, or '-' for stdin.")?;
+    if dst == "-" {
+        let mut constraint_txt = String::with_capacity(100);
+        let mut stdin = io::stdin();
+        stdin
+            .read_to_string(&mut constraint_txt)
+            .map_err(|e| e.to_string())?;
+        Ok(constraint_txt)
+    } else {
+        std::fs::read_to_string(dst).map_err(|e| e.to_string())
+    }
+}

--- a/justfile
+++ b/justfile
@@ -3,6 +3,9 @@ clippy-flags := "--workspace --tests --benches --examples"
 lint:
     cargo clippy {{clippy-flags}} -- -D warnings
 
+lint-fix:
+    cargo clippy {{clippy-flags}} --fix -- -D warnings
+
 check-wasm:
     cargo check -p ezpz-wasm --target wasm32-unknown-unknown
     cd ezpz-wasm; wasm-pack build --target web --dev; cd -

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -16,7 +16,6 @@ winnow = { version = "0.7.13" }
 [dev-dependencies]
 criterion = "0.7.0"
 
-
 [[bench]]
 name = "solver_bench"
 harness = false

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = "2.0.14"
 
 [dev-dependencies]
 criterion = "0.7.0"
+winnow = "0.7.13"
 
 [[bench]]
 name = "solver_bench"

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -11,10 +11,11 @@ kittycad-modeling-cmds = "0.2.131"
 libm = "0.2.15"
 newton_faer = { git = "https://github.com/adamchalmers/newton-faer", branch = "achalmers/fallible" }
 thiserror = "2.0.14"
+winnow = { version = "0.7.13" }
 
 [dev-dependencies]
 criterion = "0.7.0"
-winnow = "0.7.13"
+
 
 [[bench]]
 name = "solver_bench"

--- a/kcl-ezpz/src/datatypes.rs
+++ b/kcl-ezpz/src/datatypes.rs
@@ -19,8 +19,8 @@ impl DatumDistance {
 /// 2D point.
 #[derive(Clone, Copy)]
 pub struct DatumPoint {
-    x_id: Id,
-    y_id: Id,
+    pub(crate) x_id: Id,
+    pub(crate) y_id: Id,
 }
 
 impl DatumPoint {

--- a/kcl-ezpz/src/lib.rs
+++ b/kcl-ezpz/src/lib.rs
@@ -17,8 +17,7 @@ mod solver;
 #[cfg(test)]
 mod tests;
 /// Parser for textual representation of these problems.
-#[cfg(test)]
-mod textual;
+pub mod textual;
 
 const EPSILON: f64 = 0.00000001;
 

--- a/kcl-ezpz/src/lib.rs
+++ b/kcl-ezpz/src/lib.rs
@@ -16,6 +16,9 @@ mod solver;
 /// Unit tests
 #[cfg(test)]
 mod tests;
+/// Parser for textual representation of these problems.
+#[cfg(test)]
+mod textual;
 
 const EPSILON: f64 = 0.00000001;
 
@@ -25,6 +28,12 @@ pub enum Error {
     NonLinearSystemError(NonLinearSystemError),
     #[error("Solver error {0}")]
     Solver(Box<dyn std::error::Error>),
+    #[error("No guess was given for point {label}")]
+    MissingGuess { label: String },
+    #[error("You gave a guess for points which weren't defined: {labels:?}")]
+    UnusedGuesses { labels: Vec<String> },
+    #[error("You referred to the point {label} but it was never defined")]
+    UndefinedPoint { label: String },
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -31,101 +31,55 @@ fn simple() {
 
 #[test]
 fn rectangle() {
-    let mut id_generator = IdGenerator::default();
-    // First square (lower case IDs)
-    let p0 = DatumPoint::new(&mut id_generator);
-    let p1 = DatumPoint::new(&mut id_generator);
-    let p2 = DatumPoint::new(&mut id_generator);
-    let p3 = DatumPoint::new(&mut id_generator);
-    let line0_bottom = LineSegment::new(p0, p1);
-    let line0_right = LineSegment::new(p1, p2);
-    let line0_top = LineSegment::new(p2, p3);
-    let line0_left = LineSegment::new(p3, p0);
-    let constraints0 = vec![
-        Constraint::Fixed(p0.id_x(), 1.0),
-        Constraint::Fixed(p0.id_y(), 1.0),
-        Constraint::Horizontal(line0_bottom),
-        Constraint::Horizontal(line0_top),
-        Constraint::Vertical(line0_left),
-        Constraint::Vertical(line0_right),
-        Constraint::Distance(p0, p1, 4.0),
-        Constraint::Distance(p0, p3, 3.0),
-    ];
+    let mut txt = "\
+    # constraints
+    point p0
+    point p1
+    point p2
+    point p3
+    p0.x = 1
+    p0.y = 1
+    horizontal(p0, p1)
+    horizontal(p2, p3)
+    vertical(p1, p2)
+    vertical(p3, p0)
+    distance(p0, p1, 4)
+    distance(p0, p3, 3)
+    point p4
+    point p5
+    point p6
+    point p7
+    p4.x = 2
+    p4.y = 2
+    horizontal(p4, p5)
+    horizontal(p6, p7)
+    vertical(p5, p6)
+    vertical(p7, p4)
+    distance(p4, p5, 4)
+    distance(p4, p7, 4)
 
-    // Second square (upper case IDs)
-    let p4 = DatumPoint::new(&mut id_generator);
-    let p5 = DatumPoint::new(&mut id_generator);
-    let p6 = DatumPoint::new(&mut id_generator);
-    let p7 = DatumPoint::new(&mut id_generator);
-    let line1_bottom = LineSegment::new(p4, p5);
-    let line1_right = LineSegment::new(p5, p6);
-    let line1_top = LineSegment::new(p6, p7);
-    let line1_left = LineSegment::new(p7, p4);
-
-    // Start p at the origin, and q at (1,9)
-    let initial_guesses = vec![
-        // First square.
-        (p0.id_x(), 1.0),
-        (p0.id_y(), 1.0),
-        (p1.id_x(), 4.5),
-        (p1.id_y(), 1.5),
-        (p2.id_x(), 4.0),
-        (p2.id_y(), 3.5),
-        (p3.id_x(), 1.5),
-        (p3.id_y(), 3.0),
-        // Second square.
-        (p4.id_x(), 2.0),
-        (p4.id_y(), 2.0),
-        (p5.id_x(), 5.5),
-        (p5.id_y(), 3.5),
-        (p6.id_x(), 5.0),
-        (p6.id_y(), 4.5),
-        (p7.id_x(), 2.5),
-        (p7.id_y(), 4.0),
-    ];
-
-    let constraints1 = vec![
-        Constraint::Fixed(p4.id_x(), 2.0),
-        Constraint::Fixed(p4.id_y(), 2.0),
-        Constraint::Horizontal(line1_bottom),
-        Constraint::Horizontal(line1_top),
-        Constraint::Vertical(line1_left),
-        Constraint::Vertical(line1_right),
-        Constraint::Distance(p4, p5, 4.0),
-        Constraint::Distance(p4, p7, 4.0),
-    ];
-
-    let mut constraints = constraints0;
-    constraints.extend(constraints1);
-    let actual = solve(constraints, initial_guesses).unwrap();
+    # guesses
+    p0 roughly (1,1)
+    p1 roughly (4.5,1.5)
+    p2 roughly (4.0,3.5)
+    p3 roughly (1.5,3.0)
+    p4 roughly (2,2)
+    p5 roughly (5.5,3.5)
+    p6 roughly (5,4.5)
+    p7 roughly (2.5,4)
+    ";
+    let problem = Problem::parse(&mut txt).unwrap();
+    let solved = problem.solve().unwrap();
     // This forms two rectangles.
-    assert_eq!(
-        actual.final_values,
-        vec![
-            1.0, 1.0, 5.0, 1.0, 5.0, 4.0, 1.0, 4.0, 2.0, 2.0, 6.0, 2.0, 6.0, 6.0, 2.0, 6.0
-        ]
-    );
-    assert!(actual.iterations <= 10)
-    // Uncomment this to print out the points nicely.
-    // for (point_num, (i, j)) in [
-    //     // first square
-    //     (0, 1),
-    //     (2, 3),
-    //     (4, 5),
-    //     (6, 7),
-    //     // second square
-    //     (8, 9),
-    //     (10, 11),
-    //     (12, 13),
-    //     (14, 15),
-    // ]
-    // .into_iter()
-    // .enumerate()
-    // {
-    //     let x = actual.final_values[i];
-    //     let y = actual.final_values[j];
-    //     eprintln!("p{point_num}: ({x},{y})");
-    // }
+    assert_eq!(solved.get_point("p0").unwrap(), Point { x: 1.0, y: 1.0 });
+    assert_eq!(solved.get_point("p1").unwrap(), Point { x: 5.0, y: 1.0 });
+    assert_eq!(solved.get_point("p2").unwrap(), Point { x: 5.0, y: 4.0 });
+    assert_eq!(solved.get_point("p3").unwrap(), Point { x: 1.0, y: 4.0 });
+    // Second rectangle
+    assert_eq!(solved.get_point("p4").unwrap(), Point { x: 2.0, y: 2.0 });
+    assert_eq!(solved.get_point("p5").unwrap(), Point { x: 6.0, y: 2.0 });
+    assert_eq!(solved.get_point("p6").unwrap(), Point { x: 6.0, y: 6.0 });
+    assert_eq!(solved.get_point("p7").unwrap(), Point { x: 2.0, y: 6.0 });
 }
 
 #[test]

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -2,6 +2,7 @@ mod executor;
 mod instruction;
 mod parser;
 
+pub use executor::Outcome;
 use instruction::Instruction;
 
 #[derive(Debug, PartialEq)]

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -1,0 +1,63 @@
+mod executor;
+mod instruction;
+mod parser;
+
+use instruction::Instruction;
+
+#[derive(Debug, PartialEq)]
+pub struct PointGuess {
+    pub point: Label,
+    pub guess: Point,
+}
+
+#[derive(Debug)]
+pub struct Problem {
+    pub instructions: Vec<Instruction>,
+    pub inner_points: Vec<Label>,
+    pub point_guesses: Vec<PointGuess>,
+}
+
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug)]
+pub enum Component {
+    X,
+    Y,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub struct Label(String);
+
+impl From<&str> for Label {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl PartialEq<&str> for Label {
+    fn eq(&self, other: &&str) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<String> for Label {
+    fn eq(&self, other: &String) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<str> for Label {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl Problem {
+    pub fn points(&self) -> &[Label] {
+        &self.inner_points
+    }
+}

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+
+use crate::Constraint;
+use crate::Error;
+use crate::IdGenerator;
+use crate::Lint;
+use crate::SolveOutcome;
+use crate::datatypes::DatumPoint;
+use crate::datatypes::LineSegment;
+use crate::textual::Component;
+use crate::textual::Label;
+use crate::textual::Point;
+use crate::textual::instruction::FixPointComponent;
+use crate::textual::instruction::Horizontal;
+use crate::textual::instruction::Vertical;
+
+use super::Instruction;
+use super::Problem;
+
+impl Problem {
+    pub fn solve(self) -> Result<Outcome, Error> {
+        // First, construct the list of initial guesses,
+        // and assign them to solver variables.
+        let num_points = self.inner_points.len();
+        let mut id_generator = IdGenerator::default();
+        let mut initial_guesses: Vec<_> = Vec::with_capacity(self.inner_points.len() * 2);
+        let mut guessmap = HashMap::new();
+        guessmap.extend(
+            self.point_guesses
+                .into_iter()
+                .map(|pg| (pg.point.0, pg.guess)),
+        );
+        for point in &self.inner_points {
+            let Some(guess) = guessmap.remove(&point.0) else {
+                return Err(Error::MissingGuess {
+                    label: point.0.clone(),
+                });
+            };
+            initial_guesses.push((id_generator.next_id(), guess.x));
+            initial_guesses.push((id_generator.next_id(), guess.y));
+        }
+        if !guessmap.is_empty() {
+            let labels: Vec<String> = guessmap.keys().cloned().collect();
+            return Err(Error::UnusedGuesses { labels });
+        }
+
+        // Good. Now we can define all the constraints, referencing the solver variables that
+        // were defined in the previous step.
+        let mut constraints = Vec::new();
+        let datum_point_for_label = |label: &Label| -> Result<DatumPoint, crate::Error> {
+            let point_id = self.inner_points.iter().position(|p| p == &label.0).ok_or(
+                Error::UndefinedPoint {
+                    label: label.0.clone(),
+                },
+            )?;
+            let x_id = initial_guesses[2 * point_id].0;
+            let y_id = initial_guesses[2 * point_id + 1].0;
+            Ok(DatumPoint { x_id, y_id })
+        };
+
+        for instr in self.instructions {
+            match instr {
+                Instruction::DeclarePoint(_) => {}
+                Instruction::FixPointComponent(FixPointComponent {
+                    point,
+                    component,
+                    value,
+                }) => {
+                    let point_id = self
+                        .inner_points
+                        .iter()
+                        .position(|p| p == &point)
+                        .ok_or(Error::UndefinedPoint { label: point.0 })?;
+                    let index = match component {
+                        Component::X => 2 * point_id,
+                        Component::Y => 2 * point_id + 1,
+                    };
+                    let id = initial_guesses[index].0;
+                    constraints.push(Constraint::Fixed(id, value));
+                }
+                Instruction::Vertical(Vertical { label }) => {
+                    let p0 = datum_point_for_label(&label.0)?;
+                    let p1 = datum_point_for_label(&label.1)?;
+                    constraints.push(Constraint::Vertical(LineSegment { p0, p1 }));
+                }
+                Instruction::Horizontal(Horizontal { label }) => {
+                    let p0 = datum_point_for_label(&label.0)?;
+                    let p1 = datum_point_for_label(&label.1)?;
+                    constraints.push(Constraint::Horizontal(LineSegment { p0, p1 }));
+                }
+            }
+        }
+
+        let num_vars = initial_guesses.len();
+        let num_eqs = constraints.iter().map(|c| c.residual_dim()).sum();
+
+        // Pass into the solver.
+        let SolveOutcome {
+            iterations,
+            lints,
+            final_values,
+        } = crate::solve(constraints, initial_guesses)?;
+        eprintln!("{final_values:?}");
+
+        let mut final_points = HashMap::with_capacity(num_points);
+        for (i, point) in self.inner_points.into_iter().enumerate() {
+            let x_id = 2 * i;
+            let y_id = 2 * i + 1;
+            let p = Point {
+                x: final_values[x_id],
+                y: final_values[y_id],
+            };
+            final_points.insert(point.0, p);
+        }
+        Ok(Outcome {
+            iterations,
+            lints,
+            points: final_points,
+            num_vars,
+            num_eqs,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct Outcome {
+    pub iterations: usize,
+    pub lints: Vec<Lint>,
+    pub points: HashMap<String, Point>,
+    pub num_vars: usize,
+    pub num_eqs: usize,
+}
+
+impl Outcome {
+    pub fn get_point(&self, label: &str) -> Option<Point> {
+        self.points.get(label).copied()
+    }
+}

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -10,6 +10,7 @@ use crate::datatypes::LineSegment;
 use crate::textual::Component;
 use crate::textual::Label;
 use crate::textual::Point;
+use crate::textual::instruction::Distance;
 use crate::textual::instruction::FixPointComponent;
 use crate::textual::instruction::Horizontal;
 use crate::textual::instruction::Vertical;
@@ -87,6 +88,11 @@ impl Problem {
                     let p0 = datum_point_for_label(&label.0)?;
                     let p1 = datum_point_for_label(&label.1)?;
                     constraints.push(Constraint::Horizontal(LineSegment { p0, p1 }));
+                }
+                Instruction::Distance(Distance { label, distance }) => {
+                    let p0 = datum_point_for_label(&label.0)?;
+                    let p1 = datum_point_for_label(&label.1)?;
+                    constraints.push(Constraint::Distance(p0, p1, *distance));
                 }
             }
         }

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -6,6 +6,13 @@ pub enum Instruction {
     FixPointComponent(FixPointComponent),
     Vertical(Vertical),
     Horizontal(Horizontal),
+    Distance(Distance),
+}
+
+#[derive(Debug)]
+pub struct Distance {
+    pub label: (Label, Label),
+    pub distance: f64,
 }
 
 #[derive(Debug)]

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -1,0 +1,31 @@
+use super::{Component, Label};
+
+#[derive(Debug)]
+pub enum Instruction {
+    DeclarePoint(DeclarePoint),
+    FixPointComponent(FixPointComponent),
+    Vertical(Vertical),
+    Horizontal(Horizontal),
+}
+
+#[derive(Debug)]
+pub struct Vertical {
+    pub label: (Label, Label),
+}
+
+#[derive(Debug)]
+pub struct Horizontal {
+    pub label: (Label, Label),
+}
+
+#[derive(Debug)]
+pub struct DeclarePoint {
+    pub label: Label,
+}
+
+#[derive(Debug)]
+pub struct FixPointComponent {
+    pub point: Label,
+    pub component: Component,
+    pub value: f64,
+}

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -1,3 +1,5 @@
+use crate::textual::instruction::Distance;
+
 use super::{
     Component, Label, Point, PointGuess, Problem,
     instruction::{DeclarePoint, FixPointComponent, Horizontal, Instruction, Vertical},
@@ -96,6 +98,29 @@ impl Vertical {
     }
 }
 
+impl Distance {
+    pub fn parse(i: &mut &str) -> WResult<Self> {
+        let _ = "distance".parse_next(i)?;
+        ignore_ws(i);
+        let _ = '('.parse_next(i)?;
+        ignore_ws(i);
+        let p0 = Label::parse(i)?;
+        let _ = ','.parse_next(i)?;
+        ignore_ws(i);
+        let p1 = Label::parse(i)?;
+        ignore_ws(i);
+        let _ = ','.parse_next(i)?;
+        ignore_ws(i);
+        let distance = parse_number(i)?;
+        ignore_ws(i);
+        let _ = ')'.parse_next(i)?;
+        Ok(Self {
+            label: (p0, p1),
+            distance,
+        })
+    }
+}
+
 impl Instruction {
     fn parse(i: &mut &str) -> WResult<Self> {
         ignore_ws(i);
@@ -104,6 +129,7 @@ impl Instruction {
             FixPointComponent::parse.map(Instruction::FixPointComponent),
             Horizontal::parse.map(Instruction::Horizontal),
             Vertical::parse.map(Instruction::Vertical),
+            Distance::parse.map(Instruction::Distance),
         ))
         .parse_next(i)
     }

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -1,0 +1,176 @@
+use super::{
+    Component, Label, Point, PointGuess, Problem,
+    instruction::{DeclarePoint, FixPointComponent, Horizontal, Instruction, Vertical},
+};
+use winnow::{
+    Result as WResult,
+    ascii::{alphanumeric1, digit1, newline, space0},
+    combinator::{alt, delimited, eof, opt, separated},
+    prelude::*,
+};
+
+impl Problem {
+    pub fn parse(i: &mut &str) -> WResult<Self> {
+        constraint_header.parse_next(i)?;
+        let instructions: Vec<_> = separated(1.., Instruction::parse, newline).parse_next(i)?;
+        let mut inner_points = Vec::new();
+        for instr in &instructions {
+            if let Instruction::DeclarePoint(dp) = instr {
+                inner_points.push(dp.label.clone());
+            }
+        }
+        newline.parse_next(i)?;
+        newline.parse_next(i)?;
+        ignore_ws(i);
+        guesses_header.parse_next(i)?;
+        let point_guesses: Vec<_> = separated(1.., PointGuess::parse, newline).parse_next(i)?;
+        opt(newline).parse_next(i)?;
+        ignore_ws(i);
+        eof.parse_next(i)?;
+        Ok(Self {
+            instructions,
+            inner_points,
+            point_guesses,
+        })
+    }
+}
+
+impl PointGuess {
+    // p roughly (0, 0)
+    pub fn parse(i: &mut &str) -> WResult<Self> {
+        ignore_ws(i);
+        let label = Label::parse(i)?;
+        ws.parse_next(i)?;
+        let _ = "roughly".parse_next(i)?;
+        ws.parse_next(i)?;
+        let guess = Point::parse(i)?;
+        Ok(Self {
+            point: label,
+            guess,
+        })
+    }
+}
+
+fn constraint_header(i: &mut &str) -> WResult<()> {
+    ('#', ws, "constraints", newline).map(|_| ()).parse_next(i)
+}
+fn guesses_header(i: &mut &str) -> WResult<()> {
+    ('#', ws, "guesses", newline).map(|_| ()).parse_next(i)
+}
+
+impl DeclarePoint {
+    pub fn parse(i: &mut &str) -> WResult<Self> {
+        ("point", ws, Label::parse)
+            .map(|(_, _, label)| Self { label })
+            .parse_next(i)
+    }
+}
+
+impl Horizontal {
+    pub fn parse(i: &mut &str) -> WResult<Self> {
+        let _ = "horizontal".parse_next(i)?;
+        ignore_ws(i);
+        let _ = '('.parse_next(i)?;
+        ignore_ws(i);
+        let p0 = Label::parse(i)?;
+        let _ = ','.parse_next(i)?;
+        ignore_ws(i);
+        let p1 = Label::parse(i)?;
+        let _ = ')'.parse_next(i)?;
+        Ok(Self { label: (p0, p1) })
+    }
+}
+
+impl Vertical {
+    pub fn parse(i: &mut &str) -> WResult<Self> {
+        let _ = "vertical".parse_next(i)?;
+        ignore_ws(i);
+        let _ = '('.parse_next(i)?;
+        ignore_ws(i);
+        let p0 = Label::parse(i)?;
+        let _ = ','.parse_next(i)?;
+        ignore_ws(i);
+        let p1 = Label::parse(i)?;
+        let _ = ')'.parse_next(i)?;
+        Ok(Self { label: (p0, p1) })
+    }
+}
+
+impl Instruction {
+    fn parse(i: &mut &str) -> WResult<Self> {
+        ignore_ws(i);
+        alt((
+            DeclarePoint::parse.map(Instruction::DeclarePoint),
+            FixPointComponent::parse.map(Instruction::FixPointComponent),
+            Horizontal::parse.map(Instruction::Horizontal),
+            Vertical::parse.map(Instruction::Vertical),
+        ))
+        .parse_next(i)
+    }
+}
+
+fn ws(i: &mut &str) -> WResult<()> {
+    space0.parse_next(i).map(|_| ())
+}
+
+fn ignore_ws(i: &mut &str) {
+    let _ = ws.parse_next(i);
+}
+
+impl Component {
+    fn parse(i: &mut &str) -> WResult<Self> {
+        alt(('x'.map(|_| Self::X), 'y'.map(|_| Self::Y))).parse_next(i)
+    }
+}
+
+impl FixPointComponent {
+    fn parse(i: &mut &str) -> WResult<FixPointComponent> {
+        (
+            Label::parse,
+            '.',
+            Component::parse,
+            delimited(space0, '=', space0),
+            parse_number,
+        )
+            .map(
+                |(label, _dot, component, _equals, value)| FixPointComponent {
+                    point: label,
+                    component,
+                    value,
+                },
+            )
+            .parse_next(i)
+    }
+}
+
+impl Label {
+    fn parse(i: &mut &str) -> WResult<Label> {
+        alphanumeric1
+            .map(|s: &str| Label(s.to_owned()))
+            .parse_next(i)
+    }
+}
+
+impl Point {
+    pub fn parse(input: &mut &str) -> WResult<Point> {
+        delimited(
+            '(',
+            (parse_number, ',', space0, parse_number).map(|(x, _comma, _space, y)| Point { x, y }),
+            ')',
+        )
+        .parse_next(input)
+    }
+}
+
+fn parse_number(i: &mut &str) -> WResult<f64> {
+    fn myint(input: &mut &str) -> WResult<f64> {
+        digit1
+            .verify_map(|s: &str| s.parse::<f64>().ok())
+            .parse_next(input)
+    }
+
+    fn myfloat(i: &mut &str) -> WResult<f64> {
+        winnow::ascii::float.parse_next(i)
+    }
+    alt((myfloat, myint)).parse_next(i)
+}

--- a/test_cases/tiny.txt
+++ b/test_cases/tiny.txt
@@ -1,0 +1,11 @@
+# constraints
+point p
+point q
+p.x = 0
+p.y = 0
+q.y = 0
+vertical(p, q)
+
+# guesses
+p roughly (3, 4)
+q roughly (5, 6)


### PR DESCRIPTION
Introduces a textual representation for stating constraint systems. It has two sections: a section for defining geometry and constraints on it, then a section for defining your initial guesses.

```
# constraints
point p
point q
p.x = 0
p.y = 0
q.y = 0
vertical(p, q)

# guesses
p roughly (3, 4)
q roughly (5, 6)
```

You can use this in the unit tests, or in a tiny little CLI I've added to this project.

<img width="901" height="519" alt="Screenshot 2025-08-23 at 12 34 15 PM" src="https://github.com/user-attachments/assets/88619cbe-d930-44b1-a015-9f4f67276ddb" />
