### PR TITLE
Migrate another test to textual fmt

### DIFF
--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -3,7 +3,7 @@ use kittycad_modeling_cmds::shared::Angle;
 use crate::{EPSILON, NonLinearSystemError, datatypes::*, id::Id, solver::Layout};
 
 /// Each geometric constraint we support.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Constraint {
     /// These two points should be a given distance apart.
     Distance(DatumPoint, DatumPoint, Distance),
@@ -17,7 +17,7 @@ pub enum Constraint {
     Fixed(Id, f64),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum AngleKind {
     Parallel,
     Perpendicular,
@@ -422,7 +422,7 @@ impl Constraint {
 }
 
 /// Euclidean distance between two points.
-fn euclidean_distance(p0: (f64, f64), p1: (f64, f64)) -> f64 {
+pub(crate) fn euclidean_distance(p0: (f64, f64), p1: (f64, f64)) -> f64 {
     let dx = p0.0 - p1.0;
     let dy = p0.1 - p1.1;
     (dx.powf(2.0) + dy.powf(2.0)).sqrt()

--- a/kcl-ezpz/src/datatypes.rs
+++ b/kcl-ezpz/src/datatypes.rs
@@ -17,7 +17,7 @@ impl DatumDistance {
 }
 
 /// 2D point.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct DatumPoint {
     pub(crate) x_id: Id,
     pub(crate) y_id: Id,
@@ -45,7 +45,7 @@ impl DatumPoint {
 }
 
 /// Line of infinite length.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct DatumLine {
     // Unusual representation of a line using two parameters, theta and A
     theta: Angle,
@@ -69,7 +69,7 @@ impl DatumLine {
 }
 
 /// Finite segment of a line.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct LineSegment {
     pub p0: DatumPoint,
     pub p1: DatumPoint,

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -24,6 +24,19 @@ pub struct Point {
     pub y: f64,
 }
 
+impl std::fmt::Display for Point {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({},{})", self.x, self.y)
+    }
+}
+
+impl Point {
+    #[allow(dead_code)]
+    pub(crate) fn euclidean_distance(&self, r: Point) -> f64 {
+        crate::constraints::euclidean_distance((self.x, self.y), (r.x, r.y))
+    }
+}
+
 #[derive(Debug)]
 pub enum Component {
     X,

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -13,6 +13,7 @@ use crate::textual::Point;
 use crate::textual::instruction::Distance;
 use crate::textual::instruction::FixPointComponent;
 use crate::textual::instruction::Horizontal;
+use crate::textual::instruction::Parallel;
 use crate::textual::instruction::Vertical;
 
 use super::Instruction;
@@ -93,6 +94,16 @@ impl Problem {
                     let p0 = datum_point_for_label(&label.0)?;
                     let p1 = datum_point_for_label(&label.1)?;
                     constraints.push(Constraint::Distance(p0, p1, *distance));
+                }
+                Instruction::Parallel(Parallel { line0, line1 }) => {
+                    let p0 = datum_point_for_label(&line0.0)?;
+                    let p1 = datum_point_for_label(&line0.1)?;
+                    let p2 = datum_point_for_label(&line1.0)?;
+                    let p3 = datum_point_for_label(&line1.1)?;
+                    constraints.push(Constraint::lines_parallel([
+                        LineSegment { p0, p1 },
+                        LineSegment { p0: p2, p1: p3 },
+                    ]));
                 }
             }
         }

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -7,12 +7,19 @@ pub enum Instruction {
     Vertical(Vertical),
     Horizontal(Horizontal),
     Distance(Distance),
+    Parallel(Parallel),
 }
 
 #[derive(Debug)]
 pub struct Distance {
     pub label: (Label, Label),
     pub distance: f64,
+}
+
+#[derive(Debug)]
+pub struct Parallel {
+    pub line0: (Label, Label),
+    pub line1: (Label, Label),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Includes textual format for parallel constraints and sqrts.