### PR TITLE
Move gnuplot visualization out of unit tests, into CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -229,6 +273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -237,8 +282,22 @@ version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -261,6 +320,12 @@ name = "coe-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8f1e641542c07631228b1e0dc04b69ae3c1d58ef65d5691a439711d805c698"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -565,9 +630,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ezpz-cli"
+name = "ezpz"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "kcl-ezpz",
 ]
 
@@ -1255,6 +1321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1691,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -2337,6 +2415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "structmeta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +2656,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/ezpz-cli/Cargo.toml
+++ b/ezpz-cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "ezpz-cli"
+name = "ezpz"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.45", features = ["derive"] }
 kcl-ezpz = { path = "../kcl-ezpz" }

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -106,67 +106,6 @@ fn angle_constraints() {
     assert_points_eq(solved.get_point("p2").unwrap(), Point { x: 8.0, y: 8.0 });
 }
 
-/// Open a `gnuplot` window displaying these points in a 2D scatter plot.
-#[allow(dead_code)]
-fn pop_gnuplot_window(chart_name: &str, points: Vec<((f64, f64), &str)>) {
-    let gnuplot_program = gnuplot(chart_name, points);
-    let mut child = std::process::Command::new("gnuplot")
-        .args(["-persist", "-"])
-        .stdin(std::process::Stdio::piped())
-        .spawn()
-        .expect("failed to start gnuplot");
-
-    {
-        let stdin = child.stdin.as_mut().expect("failed to open stdin");
-        use std::io::Write;
-        stdin
-            .write_all(gnuplot_program.as_bytes())
-            .expect("failed to write to stdin");
-    }
-    let _ = child.wait();
-}
-
-/// Write a gnuplot program to show these points in a 2D scatter plot.
-fn gnuplot(chart_name: &str, points: Vec<((f64, f64), &str)>) -> String {
-    let all_points = points
-        .iter()
-        .map(|((x, y), _label)| format!("{x} {y}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let all_labels = points
-        .iter()
-        .map(|((x, y), label)| format!("set label \"{label} ({x}, {y})\" at {x},{y} offset 1,1"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let components = points
-        .into_iter()
-        .flat_map(|((x, y), _label)| [x, y])
-        .collect::<Vec<_>>();
-    let min = components.iter().cloned().fold(f64::NAN, f64::min);
-    let max = components.iter().cloned().fold(f64::NAN, f64::max);
-    format!(
-        "set title \"{chart_name}\"
-set xlabel \"X\"
-set ylabel \"Y\"
-set grid
-
-set xrange [{min}:{max}]
-set yrange [{min}:{max}]
-
-# Plot the points
-plot \"-\" with points pointtype 7 pointsize 2 title \"Points\"
-{all_points}
-e
-
-# Add labels for each point
-{all_labels}
-
-# Refresh plot to show labels
-replot
-"
-    )
-}
-
 #[track_caller]
 fn assert_points_eq(l: Point, r: Point) {
     let dist = l.euclidean_distance(r);

--- a/test_cases/angle_parallel.txt
+++ b/test_cases/angle_parallel.txt
@@ -1,0 +1,15 @@
+# constraints
+point p0
+point p1
+point p2
+p0.x = 0
+p0.y = 0
+parallel(p0, p1, p1, p2)
+distance(p0, p1, sqrt(32))
+distance(p1, p2, sqrt(32))
+p1.x = 4
+
+# guesses
+p0 roughly (0,0)
+p1 roughly (3,3)
+p2 roughly (6,6)


### PR DESCRIPTION
Adds `clap` for CLI parsing so we can get nice little flags etc. Now it's easy to visualize a constraint system. You can easily read the constraint system from stdin or from a file.

<img width="828" height="702" alt="Screenshot 2025-08-25 at 5 42 40 AM" src="https://github.com/user-attachments/assets/8c189b9a-c7b7-479a-97b6-977b45484fc4" />
