### PR TITLE
Treat IDs as indices

### DIFF
--- a/kcl-ezpz/src/solver.rs
+++ b/kcl-ezpz/src/solver.rs
@@ -29,7 +29,7 @@ impl RowMap for Layout {
 
 impl Layout {
     pub fn index_of(&self, var: <Layout as RowMap>::Var) -> Result<usize, NonLinearSystemError> {
-        lookup(var, &self.all_variables)
+        Ok(var as usize)
     }
 
     pub fn num_cols(&self) -> usize {


### PR DESCRIPTION
Now that our variable IDs are just auto-incrementing ints, their numeric value is always the same as their index/position in the array of variables. This means we don't need to do a linear search anymore, ID 2 is always index 2. To put it another way, `index_of` is just the identity function.

This halves the time spent on each solve, doubling throughput on benchmarks.