### PR TITLE
Remove more vector allocations

### DIFF
--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -71,30 +71,24 @@ impl IntoIterator for JacobianRow {
 
 impl Constraint {
     /// For each row of the Jacobian matrix, which variables are involved in them?
-    pub fn nonzeroes(&self) -> Vec<Vec<Id>> {
+    pub fn nonzeroes(&self, row0: &mut Vec<Id>) {
         match self {
             Constraint::Distance(p0, p1, _dist) => {
-                vec![vec![p0.id_x(), p0.id_y(), p1.id_x(), p1.id_y()]]
+                row0.extend([p0.id_x(), p0.id_y(), p1.id_x(), p1.id_y()])
             }
-            Constraint::Vertical(line) => {
-                vec![vec![line.p0.id_x(), line.p1.id_x()]]
-            }
-            Constraint::Horizontal(line) => {
-                vec![vec![line.p0.id_y(), line.p1.id_y()]]
-            }
-            Constraint::LinesAtAngle(line0, line1, _angle) => {
-                vec![vec![
-                    line0.p0.id_x(),
-                    line0.p0.id_y(),
-                    line0.p1.id_x(),
-                    line0.p1.id_y(),
-                    line1.p0.id_x(),
-                    line1.p0.id_y(),
-                    line1.p1.id_x(),
-                    line1.p1.id_y(),
-                ]]
-            }
-            Constraint::Fixed(id, _scalar) => vec![vec![*id]],
+            Constraint::Vertical(line) => row0.extend([line.p0.id_x(), line.p1.id_x()]),
+            Constraint::Horizontal(line) => row0.extend([line.p0.id_y(), line.p1.id_y()]),
+            Constraint::LinesAtAngle(line0, line1, _angle) => row0.extend([
+                line0.p0.id_x(),
+                line0.p0.id_y(),
+                line0.p1.id_x(),
+                line0.p1.id_y(),
+                line1.p0.id_x(),
+                line1.p0.id_y(),
+                line1.p1.id_x(),
+                line1.p1.id_y(),
+            ]),
+            Constraint::Fixed(id, _scalar) => row0.push(*id),
         }
     }
 

--- a/kcl-ezpz/src/solver.rs
+++ b/kcl-ezpz/src/solver.rs
@@ -117,22 +117,23 @@ impl<'c> Model<'c> {
         // Generate the matrix.
         let mut pairs: Vec<Pair<usize, usize>> = Vec::with_capacity(num_cols * num_rows);
         let mut row_num = 0;
+        let mut nonzeroes_scratch = Vec::with_capacity(4);
         for constraint in constraints {
-            let rows = constraint.nonzeroes();
+            nonzeroes_scratch.clear();
+            let () = constraint.nonzeroes(&mut nonzeroes_scratch);
             debug_assert_eq!(
-                rows.len(),
                 constraint.residual_dim(),
-                "Constraint {} should have {} rows but actually had {}",
+                1,
+                "Constraint {} has {} rows but we only passed scratch room for 1, pls update this code",
                 constraint.constraint_kind(),
                 constraint.residual_dim(),
-                rows.len(),
             );
 
-            for row in rows {
+            for row in [&nonzeroes_scratch] {
                 let this_row = row_num;
                 row_num += 1;
                 for var in row {
-                    let col = layout.index_of(var)?;
+                    let col = layout.index_of(*var)?;
                     pairs.push(Pair { row: this_row, col });
                 }
             }


### PR DESCRIPTION
Improves perf by around 17%, using the same strategy as #35 and #36 