### PR TITLE
Quiet the justfile for regen-massive-test

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,5 +40,5 @@ fmt-check:
     cargo sort --check
     typos
 
-regen-massive-test extra_lines:
+@regen-massive-test extra_lines:
     python3 test_cases/massive_parallel_system/gen_big_problem.py {{extra_lines}} > test_cases/massive_parallel_system/problem.txt


### PR DESCRIPTION
This way it doesn't print "python program.py > file.txt" when you run the command.