### PR TITLE
Handle overconstrained systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,8 +1625,7 @@ dependencies = [
 [[package]]
 name = "newton_faer"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcf64395235c636ee5ecbdcea5c831351dffceb703534770dba6e50877807fe"
+source = "git+https://github.com/KittyCAD/newtonls-faer?branch=main#38db32af167c9134b87c9e85074d15ef2beebc65"
 dependencies = [
  "dyn-stack 0.13.0",
  "error-stack",

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -12,7 +12,7 @@ getrandom = { version = "0.2.16", features = ["js"] }
 indexmap = "2.11.0"
 kittycad-modeling-cmds = "0.2.131"
 libm = "0.2.15"
-newton_faer = "0.1.2"
+newton_faer = { git = "https://github.com/KittyCAD/newtonls-faer", branch = "main" }
 thiserror = "2.0.14"
 winnow = { version = "0.7.13" }
 

--- a/kcl-ezpz/src/solver.rs
+++ b/kcl-ezpz/src/solver.rs
@@ -17,11 +17,6 @@ pub struct Layout {
 impl RowMap for Layout {
     type Var = Id;
 
-    /// Total number of rows in the matrix.
-    fn dim(&self) -> usize {
-        self.total_num_residuals
-    }
-
     // `faer_newton` stores variables in a vec, refers to them only by their offset.
     // So this function lets you look up the index of a particular variable in that vec.
     // `bus` is the row index and `var` is the variable being looked up,
@@ -30,19 +25,19 @@ impl RowMap for Layout {
         // In our system, variables are the same in every row.
         Some(var as usize)
     }
+
+    fn n_variables(&self) -> usize {
+        self.all_variables.len()
+    }
+
+    fn n_residuals(&self) -> usize {
+        self.total_num_residuals
+    }
 }
 
 impl Layout {
     pub fn index_of(&self, var: <Layout as RowMap>::Var) -> usize {
         var as usize
-    }
-
-    pub fn num_cols(&self) -> usize {
-        self.all_variables.len()
-    }
-
-    pub fn num_rows(&self) -> usize {
-        self.dim()
     }
 }
 

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -55,6 +55,15 @@ fn perpendiculars() {
     assert_points_eq(solved.get_point("p3").unwrap(), Point { x: 4.0, y: 0.0 });
 }
 
+#[test]
+fn nonsquare() {
+    let mut txt = include_str!("../../test_cases/nonsquare/problem.txt");
+    let problem = Problem::parse(&mut txt).unwrap();
+    let solved = problem.to_constraint_system().unwrap().solve().unwrap();
+    assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 0.0 });
+    assert_points_eq(solved.get_point("q").unwrap(), Point { x: 0.0, y: 0.0 });
+}
+
 #[track_caller]
 fn assert_points_eq(l: Point, r: Point) {
     let dist = l.euclidean_distance(r);

--- a/test_cases/nonsquare/problem.txt
+++ b/test_cases/nonsquare/problem.txt
@@ -1,0 +1,13 @@
+# constraints
+point p
+point q
+p.x = 0
+p.y = 0
+q.x = 0
+q.y = 0
+vertical(p, q)
+horizontal(p, q)
+
+# guesses
+p roughly (3, 4)
+q roughly (5, 6)


### PR DESCRIPTION
Switches to [our newton-faer fork](https://github.com/KittyCAD/newtonls-faer/pull/1).

Adds a new test case with a constraint system that is valid but overconstrained. Before this commit, such a system caused a runtime panic from faer (via newton-faer) that the matrix wasn't square.