### PR TITLE
Add step and gradient based convergence criteria 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package.json
 package-lock.json
 flamegraph.svg
 lcov.info
+.vscode/

--- a/kcl-ezpz/src/lib.rs
+++ b/kcl-ezpz/src/lib.rs
@@ -21,7 +21,7 @@ mod tests;
 /// Parser for textual representation of these problems.
 pub mod textual;
 
-const EPSILON: f64 = 0.001;
+const EPSILON: f64 = 1e-5;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -25,6 +25,20 @@ fn tiny() {
 }
 
 #[test]
+fn inconsistent() {
+    // This has inconsistent requirements:
+    // p should be (1,4) and it should ALSO be (4,1).
+    // Because they can't be simultaneously satisfied, we should find a
+    // solution which minimizes the squared error instead.
+    let txt = include_str!("../../test_cases/inconsistent/problem.txt");
+    let problem = parse_problem(txt);
+    let solved = problem.to_constraint_system().unwrap().solve().unwrap();
+    assert_points_eq(solved.get_point("o").unwrap(), Point { x: 0.0, y: 0.0 });
+    // (2.5, 2.5) is midway between the two inconsistent requirement points.
+    assert_points_eq(solved.get_point("p").unwrap(), Point { x: 2.5, y: 2.5 });
+}
+
+#[test]
 fn circle() {
     let txt = include_str!("../../test_cases/circle/problem.txt");
     let problem = parse_problem(txt);

--- a/newtonls-faer/src/lib.rs
+++ b/newtonls-faer/src/lib.rs
@@ -653,23 +653,6 @@ mod tests {
             }
         }
 
-        #[derive(Clone)]
-        struct Jc {
-            sym: SymbolicSparseColMat<usize>,
-            vals: Vec<f64>,
-        }
-        impl JacobianCache<f64> for Jc {
-            fn symbolic(&self) -> &SymbolicSparseColMat<usize> {
-                &self.sym
-            }
-            fn values(&self) -> &[f64] {
-                &self.vals
-            }
-            fn values_mut(&mut self) -> &mut [f64] {
-                &mut self.vals
-            }
-        }
-
         struct InconsistentSystem {
             layout: Layout,
             jac: Jc,

--- a/newtonls-faer/src/lib.rs
+++ b/newtonls-faer/src/lib.rs
@@ -4,10 +4,7 @@ mod linalg;
 mod solver;
 
 pub use linalg::{DenseLu, FaerLu, SparseQr};
-pub use solver::{
-    Control, IterationStats, Iterations, MatrixFormat, NewtonCfg, solve, solve_cb, solve_dense_cb,
-    solve_sparse_cb,
-};
+pub use solver::{Control, IterationStats, Iterations, MatrixFormat, NewtonCfg, solve, solve_cb};
 
 use core::fmt::{self, Display, Formatter};
 use core::num::NonZeroUsize;
@@ -132,8 +129,6 @@ pub fn current_parallelism() -> usize {
 
 #[cfg(test)]
 mod tests {
-    use crate::solver::NormType;
-
     use super::*;
     use faer::sparse::Pair;
     use faer::sparse::SymbolicSparseColMat;
@@ -235,15 +230,8 @@ mod tests {
         let mut model = Model::new();
         let mut x = [0.9_f64, 2.1_f64];
 
-        let iters = crate::solve_sparse_cb(
-            &mut model,
-            &mut x,
-            &mut crate::FaerLu::<f64>::default(),
-            cfg,
-            NormType::LInf,
-            |_| Control::Continue,
-        )
-        .expect("solver");
+        let iters =
+            crate::solve_cb(&mut model, &mut x, cfg, |_| Control::Continue).expect("solver");
 
         assert!(iters > 0 && iters <= 25);
         assert!((x[0] - 1.0).abs() < 1e-10);

--- a/newtonls-faer/src/solver.rs
+++ b/newtonls-faer/src/solver.rs
@@ -435,6 +435,7 @@ where
     let mut jac = FaerMat::<M::Real>::zeros(n, n);
     let mut rhs = FaerMat::<M::Real>::zeros(n, 1);
 
+    #[allow(clippy::too_many_arguments)]
     fn solve_inner<T>(
         model: &mut impl NonlinearSystem<Real = T>,
         x: &[T],
@@ -498,6 +499,7 @@ where
     let n_res = model.layout().n_residuals();
     let mut rhs = FaerMat::<M::Real>::zeros(n_res, 1);
 
+    #[allow(clippy::too_many_arguments)]
     fn solve_inner<T, S>(
         model: &mut impl NonlinearSystem<Real = T>,
         x: &[T],

--- a/newtonls-faer/src/solver.rs
+++ b/newtonls-faer/src/solver.rs
@@ -9,6 +9,9 @@ use faer_traits::ComplexField;
 use num_traits::{Float, One, ToPrimitive, Zero};
 
 const AUTO_DENSE_THRESHOLD: usize = 100;
+const FTOL_DEFAULT: f64 = 1e-8;
+const XTOL_DEFAULT: f64 = 1e-8;
+const GTOL_DEFAULT: f64 = 1e-8;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MatrixFormat {
@@ -56,9 +59,9 @@ impl<T: Float> Default for NewtonCfg<T> {
     fn default() -> Self {
         let _ = init_global_parallelism(0);
         Self {
-            tol: T::from(1e-8).expect("Type must support 1e-8 for default tolerance"),
-            tol_grad: T::from(1e-8).expect("Type must support 1e-8 for default gradient tolerance"),
-            tol_step: T::from(1e-8).expect("Type must support 1e-8 for default step tolerance"),
+            tol: T::from(FTOL_DEFAULT).unwrap(),
+            tol_grad: T::from(GTOL_DEFAULT).unwrap(),
+            tol_step: T::from(XTOL_DEFAULT).unwrap(),
             damping: T::one(),
             max_iter: 50,
             format: MatrixFormat::default(),

--- a/newtonls-faer/src/solver.rs
+++ b/newtonls-faer/src/solver.rs
@@ -424,7 +424,6 @@ where
     if use_dense {
         solve_dense_lu(model, x, cfg, on_iter)
     } else if is_square {
-        // TODO: This should be sparse LU with fallback to QR.
         solve_sparse_lu_with_qr_fallback(model, x, cfg, on_iter)
     } else {
         solve_sparse_qr(model, x, cfg, on_iter)

--- a/newtonls-faer/src/solver.rs
+++ b/newtonls-faer/src/solver.rs
@@ -520,6 +520,10 @@ where
     let n_vars = model.layout().n_variables();
     let n_res = model.layout().n_residuals();
 
+    // TODO: We need better logic here. We probably always want sparse for our
+    // use case, but exposing a smarter way of handling this could be possible.
+    // Our system might also be square but not have all rows linearly independent,
+    // which I think will tank LU decomp... so we might need a fallback to QR.
     let use_dense = match cfg.format {
         super::MatrixFormat::Dense => true,
         super::MatrixFormat::Sparse => false,

--- a/test_cases/inconsistent/problem.txt
+++ b/test_cases/inconsistent/problem.txt
@@ -1,0 +1,10 @@
+# constraints
+point p
+point o
+o = (0, 0)
+p = (1, 4)
+p = (4, 1)
+
+# guesses
+p roughly (1, 1)
+o roughly (0, 0)


### PR DESCRIPTION
This change introduces gradient and step based convergence criteria, while also making some structural changes which hopefully make the introduction of QR factorisation a little easier to wrap our heads around.

It also introduces partial derivative accumulation through (global) Jacobian assembly, with some changes to how `refresh_jacobian` works.

One thing worth noting is that I have, for the time being, retained a LU decomp attempt for square systems, and I'm not sure if we really want that. At present, LU decomp panics for singular systems and I catch that then fall back to QR, but if we can't estimate rank up front, we might just be better doing QR in all cases.

Note also, the lints test in `kcl-ezpz/src/tests.rs` looks like quite a rough system; I'm surprised it ever really worked. By virtue of points `p` and `q` being constrained to have the same Y height and for the line $\vec{pq}$ to be vertical, we're effectively making those points coincident then using that degenerate vector as an input to angle constraint. I now get a panic from the LU decomp, which I think makes sense, then we fallback to QR... but I'm not sure I would assign much meaning to the result.