### PR TITLE
Better parser error

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -2,6 +2,7 @@ use std::{
     hint::black_box,
     io::{self, Read},
     path::PathBuf,
+    str::FromStr,
     time::Duration,
 };
 
@@ -187,7 +188,7 @@ type RunResult = Result<(Outcome, Duration), FailureOutcome>;
 
 fn main_inner(cli: &Cli) -> Result<RunResult, String> {
     let constraint_txt = read_problem(cli)?;
-    let parsed = Problem::parse(&mut constraint_txt.as_str()).map_err(|e| e.to_string())?;
+    let parsed = Problem::from_str(&constraint_txt)?;
 
     // Ensure problem can be solved
     let now = std::time::Instant::now();

--- a/kcl-ezpz/benches/solver_bench.rs
+++ b/kcl-ezpz/benches/solver_bench.rs
@@ -1,4 +1,4 @@
-use std::hint::black_box;
+use std::{hint::black_box, str::FromStr};
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use kcl_ezpz::{
@@ -12,7 +12,7 @@ use newton_faer::init_global_parallelism;
 fn solve_tiny(c: &mut Criterion) {
     let txt = std::fs::read_to_string("test_cases/tiny/problem.txt").unwrap();
     c.bench_function("solve_tiny", |b| {
-        let problem = Problem::parse(&mut txt.as_str()).unwrap();
+        let problem = Problem::from_str(txt.as_str()).unwrap();
         let constraints = problem.to_constraint_system().unwrap();
         b.iter(|| {
             let _actual = black_box(constraints.solve().unwrap());
@@ -23,7 +23,7 @@ fn solve_tiny(c: &mut Criterion) {
 fn solve_two_rectangles(c: &mut Criterion) {
     let txt = std::fs::read_to_string("test_cases/two_rectangles/problem.txt").unwrap();
     c.bench_function("solve_two_rectangles", |b| {
-        let problem = Problem::parse(&mut txt.as_str()).unwrap();
+        let problem = Problem::from_str(txt.as_str()).unwrap();
         let constraints = problem.to_constraint_system().unwrap();
         b.iter(|| {
             let _actual = black_box(constraints.solve().unwrap());
@@ -34,7 +34,7 @@ fn solve_two_rectangles(c: &mut Criterion) {
 fn solve_angle_parallel(c: &mut Criterion) {
     let txt = std::fs::read_to_string("test_cases/angle_parallel/problem.txt").unwrap();
     c.bench_function("solve_angle_parallel", |b| {
-        let problem = Problem::parse(&mut txt.as_str()).unwrap();
+        let problem = Problem::from_str(txt.as_str()).unwrap();
         let constraints = problem.to_constraint_system().unwrap();
         b.iter(|| {
             let _actual = black_box(constraints.solve().unwrap());
@@ -45,7 +45,7 @@ fn solve_angle_parallel(c: &mut Criterion) {
 fn solve_nonsquare(c: &mut Criterion) {
     let txt = std::fs::read_to_string("test_cases/nonsquare/problem.txt").unwrap();
     c.bench_function("solve_nonsquare", |b| {
-        let problem = Problem::parse(&mut txt.as_str()).unwrap();
+        let problem = Problem::from_str(txt.as_str()).unwrap();
         let constraints = problem.to_constraint_system().unwrap();
         b.iter(|| {
             let _actual = black_box(constraints.solve().unwrap());
@@ -56,7 +56,7 @@ fn solve_nonsquare(c: &mut Criterion) {
 fn solve_perpendicular(c: &mut Criterion) {
     let txt = std::fs::read_to_string("test_cases/perpendicular/problem.txt").unwrap();
     c.bench_function("solve_perpendicular", |b| {
-        let problem = Problem::parse(&mut txt.as_str()).unwrap();
+        let problem = Problem::from_str(txt.as_str()).unwrap();
         let constraints = problem.to_constraint_system().unwrap();
         b.iter(|| {
             let _actual = black_box(constraints.solve().unwrap());
@@ -173,8 +173,8 @@ fn run_massive(c: &mut Criterion, overconstrained: bool) {
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _size| {
             let txt =
                 std::fs::read_to_string("test_cases/massive_parallel_system/problem.txt").unwrap();
-            let mut t = txt.as_str();
-            let problem = Problem::parse(&mut t).unwrap();
+            let t = txt.as_str();
+            let problem = Problem::from_str(t).unwrap();
             let constraints = problem.to_constraint_system().unwrap();
             b.iter(|| {
                 let _actual = black_box(constraints.solve().unwrap());

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -1,10 +1,12 @@
+use std::str::FromStr;
+
 use super::*;
 use crate::textual::{Point, Problem};
 
 #[test]
-fn simple() {
-    let mut txt = include_str!("../../test_cases/tiny/problem.txt");
-    let problem = Problem::parse(&mut txt).unwrap();
+fn tiny() {
+    let txt = include_str!("../../test_cases/tiny/problem.txt");
+    let problem = Problem::from_str(txt).unwrap();
     assert_eq!(problem.instructions.len(), 6);
     assert_eq!(problem.points(), vec!["p", "q"]);
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
@@ -14,8 +16,8 @@ fn simple() {
 
 #[test]
 fn rectangle() {
-    let mut txt = include_str!("../../test_cases/two_rectangles/problem.txt");
-    let problem = Problem::parse(&mut txt).unwrap();
+    let txt = include_str!("../../test_cases/two_rectangles/problem.txt");
+    let problem = Problem::from_str(txt).unwrap();
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
     // This forms two rectangles.
     assert_eq!(solved.get_point("p0").unwrap(), Point { x: 1.0, y: 1.0 });
@@ -31,11 +33,11 @@ fn rectangle() {
 
 #[test]
 fn angle_constraints() {
-    for mut file in [
+    for file in [
         include_str!("../../test_cases/angle_parallel/problem.txt"),
         include_str!("../../test_cases/angle_parallel_manual/problem.txt"),
     ] {
-        let problem = Problem::parse(&mut file).unwrap();
+        let problem = Problem::from_str(file).unwrap();
         let solved = problem.to_constraint_system().unwrap().solve().unwrap();
         assert_points_eq(solved.get_point("p0").unwrap(), Point { x: 0.0, y: 0.0 });
         assert_points_eq(solved.get_point("p1").unwrap(), Point { x: 4.0, y: 4.0 });
@@ -46,8 +48,8 @@ fn angle_constraints() {
 
 #[test]
 fn perpendiculars() {
-    let mut txt = include_str!("../../test_cases/perpendicular/problem.txt");
-    let problem = Problem::parse(&mut txt).unwrap();
+    let txt = include_str!("../../test_cases/perpendicular/problem.txt");
+    let problem = Problem::from_str(txt).unwrap();
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
     assert_points_eq(solved.get_point("p0").unwrap(), Point { x: 0.0, y: 0.0 });
     assert_points_eq(solved.get_point("p1").unwrap(), Point { x: 0.0, y: 4.0 });
@@ -57,8 +59,8 @@ fn perpendiculars() {
 
 #[test]
 fn nonsquare() {
-    let mut txt = include_str!("../../test_cases/nonsquare/problem.txt");
-    let problem = Problem::parse(&mut txt).unwrap();
+    let txt = include_str!("../../test_cases/nonsquare/problem.txt");
+    let problem = Problem::from_str(txt).unwrap();
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
     assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 0.0 });
     assert_points_eq(solved.get_point("q").unwrap(), Point { x: 0.0, y: 0.0 });
@@ -66,7 +68,7 @@ fn nonsquare() {
 
 #[test]
 fn lints() {
-    let mut txt = "# constraints
+    let txt = "# constraints
 point p
 point q
 p.x = 0
@@ -86,7 +88,7 @@ q roughly (5, 6)
 r roughly (3, 4)
 s roughly (5, 6)
 ";
-    let problem = Problem::parse(&mut txt).unwrap();
+    let problem = Problem::from_str(txt).unwrap();
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
     assert!(!solved.lints.is_empty());
     assert_eq!(

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -2,8 +2,13 @@ mod executor;
 mod instruction;
 mod parser;
 
+use std::str::FromStr;
+
 pub use executor::Outcome;
 use instruction::Instruction;
+use winnow::Parser;
+
+use crate::textual::parser::parse_problem;
 
 #[derive(Debug, PartialEq)]
 pub struct PointGuess {
@@ -16,6 +21,14 @@ pub struct Problem {
     pub instructions: Vec<Instruction>,
     pub inner_points: Vec<Label>,
     pub point_guesses: Vec<PointGuess>,
+}
+
+impl FromStr for Problem {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_problem.parse(s).map_err(|e| e.to_string())
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]


### PR DESCRIPTION
Now parse errors look like this:

```
parse error at line 7, column 1
  |
7 | verical(p, q)
  | ^
```

instead of 

```
ContextError { context: [], cause: None }
```