### PR TITLE
Support circle entities and CircleRadius constraints

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -214,6 +214,7 @@ fn print_output((outcome, duration): &(Outcome, Duration), show_points: bool) {
         iterations,
         lints,
         points,
+        circles,
         num_vars,
         num_eqs,
     } = outcome;
@@ -225,6 +226,11 @@ fn print_output((outcome, duration): &(Outcome, Duration), show_points: bool) {
         println!("Points:");
         for (label, Point { x, y }) in points {
             println!("\t{label}: ({x:.2}, {y:.2})",);
+        }
+        println!("Circles:");
+        for (label, kcl_ezpz::textual::Circle { radius, center }) in circles {
+            let Point { x, y } = center;
+            println!("\t{label}: center = ({x:.2}, {y:.2}), radius = {radius:.2}",);
         }
     }
 }

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -176,7 +176,7 @@ impl Constraint {
             }
             Constraint::CircleRadius(circle, expected_radius) => {
                 let actual_radius = current_assignments[layout.index_of(circle.radius.id)];
-                output.push(*expected_radius - actual_radius);
+                output.push(actual_radius - *expected_radius);
             }
         }
     }

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -27,13 +27,19 @@ pub enum AngleKind {
 }
 
 /// Describes one value in one row of the Jacobian matrix.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct JacobianVar {
     /// Which variable are we talking about?
     /// Corresponds to one column in the row.
     pub id: Id,
     /// What value is its partial derivative?
     pub partial_derivative: f64,
+}
+
+impl std::fmt::Debug for JacobianVar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "∂ id{}={}", self.id, self.partial_derivative)
+    }
 }
 
 /// One row of the Jacobian matrix.
@@ -76,9 +82,7 @@ impl Constraint {
                 line1.p1.id_y(),
             ]),
             Constraint::Fixed(id, _scalar) => row0.push(*id),
-            Constraint::CircleRadius(circle, _radius) => {
-                row0.extend([circle.center.id_x(), circle.center.id_y(), circle.radius.id])
-            }
+            Constraint::CircleRadius(circle, _radius) => row0.extend([circle.radius.id]),
         }
     }
 

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -6,7 +6,7 @@ use crate::{EPSILON, datatypes::*, id::Id, solver::Layout};
 #[derive(Clone, Copy, Debug)]
 pub enum Constraint {
     /// These two points should be a given distance apart.
-    Distance(DatumPoint, DatumPoint, Distance),
+    Distance(DatumPoint, DatumPoint, f64),
     /// These two points have the same Y value.
     Vertical(LineSegment),
     /// These two points have the same X value.
@@ -15,6 +15,8 @@ pub enum Constraint {
     LinesAtAngle(LineSegment, LineSegment, AngleKind),
     /// Some scalar value is fixed.
     Fixed(Id, f64),
+    /// Constraint radius of a circle
+    CircleRadius(Circle, f64),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -74,6 +76,9 @@ impl Constraint {
                 line1.p1.id_y(),
             ]),
             Constraint::Fixed(id, _scalar) => row0.push(*id),
+            Constraint::CircleRadius(circle, _radius) => {
+                row0.extend([circle.center.id_x(), circle.center.id_y(), circle.radius.id])
+            }
         }
     }
 
@@ -165,6 +170,10 @@ impl Constraint {
                     }
                 }
             }
+            Constraint::CircleRadius(circle, expected_radius) => {
+                let actual_radius = current_assignments[layout.index_of(circle.radius.id)];
+                output.push(*expected_radius - actual_radius);
+            }
         }
     }
 
@@ -177,6 +186,7 @@ impl Constraint {
             Constraint::Horizontal(..) => 1,
             Constraint::Fixed(..) => 1,
             Constraint::LinesAtAngle(..) => 1,
+            Constraint::CircleRadius(..) => 1,
         }
     }
 
@@ -410,6 +420,14 @@ impl Constraint {
                 ];
                 row0.extend(jvars.as_slice());
             }
+            Constraint::CircleRadius(circle, _expected_radius) => {
+                // Residual is R = r_expected - r_actual
+                // Only partial derivative which is nonzero is ∂R/∂r_current, which is 1.
+                row0.push(JacobianVar {
+                    id: circle.radius.id,
+                    partial_derivative: 1.0,
+                })
+            }
         }
     }
 
@@ -421,6 +439,7 @@ impl Constraint {
             Constraint::Horizontal(..) => "Horizontal",
             Constraint::Fixed(..) => "Fixed",
             Constraint::LinesAtAngle(..) => "LinesAtAngle",
+            Constraint::CircleRadius(..) => "CircleRadius",
         }
     }
 }

--- a/kcl-ezpz/src/datatypes.rs
+++ b/kcl-ezpz/src/datatypes.rs
@@ -3,9 +3,7 @@ use libm::{cos, sin};
 
 use crate::{IdGenerator, id::Id};
 
-/// 1D distance.
-pub type Distance = f64;
-
+#[derive(Clone, Copy, Debug)]
 pub struct DatumDistance {
     pub id: Id,
 }
@@ -82,7 +80,7 @@ impl LineSegment {
 }
 
 /// A circle.
-#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
 pub struct Circle {
     pub center: DatumPoint,
     pub radius: DatumDistance,

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -28,10 +28,14 @@ fn tiny() {
 fn circle() {
     let txt = include_str!("../../test_cases/circle/problem.txt");
     let problem = parse_problem(txt);
-    assert_eq!(problem.points(), vec!["a.center"]);
+    assert_eq!(problem.points(), vec!["p"]);
+    assert_eq!(problem.circles(), vec!["a"]);
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
-    // assert_eq!(solved.get_point("p").unwrap(), Point { x: 0.0, y: 0.0 });
-    // assert_eq!(solved.get_point("q").unwrap(), Point { x: 0.0, y: 0.0 });
+    assert_eq!(solved.get_point("p").unwrap(), Point { x: 4.0, y: 3.0 });
+    let circle_a = solved.get_circle("a").unwrap();
+    assert_nearly_eq(circle_a.radius, 39.0);
+    assert_points_eq(circle_a.center, Point { x: 0.1, y: 0.2 });
+    // assert_eq!(solved.get_circle("a").unwrap(), Circle{radius:39.0, center:Point { x: 0.0, y: 0.0 });
 }
 
 #[test]
@@ -124,4 +128,13 @@ s roughly (5, 6)
 fn assert_points_eq(l: Point, r: Point) {
     let dist = l.euclidean_distance(r);
     assert!(dist < EPSILON, "LHS was {l}, RHS was {r}, dist was {dist}");
+}
+
+#[track_caller]
+fn assert_nearly_eq(l: f64, r: f64) {
+    let diff = (l - r).abs();
+    assert!(
+        diff < EPSILON,
+        "LHS was {l}, RHS was {r}, difference was {diff}"
+    );
 }

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -3,15 +3,35 @@ use std::str::FromStr;
 use super::*;
 use crate::textual::{Point, Problem};
 
+fn parse_problem(txt: &str) -> Problem {
+    match Problem::from_str(txt) {
+        Ok(x) => x,
+        Err(e) => {
+            eprintln!("{e}");
+            panic!("Could not parse");
+        }
+    }
+}
+
 #[test]
 fn tiny() {
     let txt = include_str!("../../test_cases/tiny/problem.txt");
-    let problem = Problem::from_str(txt).unwrap();
+    let problem = parse_problem(txt);
     assert_eq!(problem.instructions.len(), 6);
     assert_eq!(problem.points(), vec!["p", "q"]);
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
     assert_eq!(solved.get_point("p").unwrap(), Point { x: 0.0, y: 0.0 });
     assert_eq!(solved.get_point("q").unwrap(), Point { x: 0.0, y: 0.0 });
+}
+
+#[test]
+fn circle() {
+    let txt = include_str!("../../test_cases/circle/problem.txt");
+    let problem = parse_problem(txt);
+    assert_eq!(problem.points(), vec!["a.center"]);
+    let solved = problem.to_constraint_system().unwrap().solve().unwrap();
+    // assert_eq!(solved.get_point("p").unwrap(), Point { x: 0.0, y: 0.0 });
+    // assert_eq!(solved.get_point("q").unwrap(), Point { x: 0.0, y: 0.0 });
 }
 
 #[test]

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -31,11 +31,14 @@ fn circle() {
     assert_eq!(problem.points(), vec!["p"]);
     assert_eq!(problem.circles(), vec!["a"]);
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
-    assert_eq!(solved.get_point("p").unwrap(), Point { x: 4.0, y: 3.0 });
+    assert_points_eq(solved.get_point("p").unwrap(), Point { x: 5.0, y: 5.0 });
     let circle_a = solved.get_circle("a").unwrap();
-    assert_nearly_eq(circle_a.radius, 39.0);
+    // From the problem:
+    // circle a
+    // radius(a, 40)
+    // a.center = (0.1, 0.2)
+    assert_nearly_eq(circle_a.radius, 40.0);
     assert_points_eq(circle_a.center, Point { x: 0.1, y: 0.2 });
-    // assert_eq!(solved.get_circle("a").unwrap(), Circle{radius:39.0, center:Point { x: 0.0, y: 0.0 });
 }
 
 #[test]

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -45,6 +45,12 @@ pub struct Point {
     pub y: f64,
 }
 
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct Circle {
+    pub radius: f64,
+    pub center: Point,
+}
+
 impl std::fmt::Display for Point {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "({},{})", self.x, self.y)
@@ -88,6 +94,9 @@ impl PartialEq<String> for Label {
 impl Problem {
     pub fn points(&self) -> &[Label] {
         &self.inner_points
+    }
+    pub fn circles(&self) -> &[Label] {
+        &self.inner_circles
     }
 }
 

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -16,11 +16,19 @@ pub struct PointGuess {
     pub guess: Point,
 }
 
+#[derive(Debug, PartialEq)]
+pub struct ScalarGuess {
+    pub scalar: Label,
+    pub guess: f64,
+}
+
 #[derive(Debug)]
 pub struct Problem {
     pub instructions: Vec<Instruction>,
     pub inner_points: Vec<Label>,
+    pub inner_circles: Vec<Label>,
     pub point_guesses: Vec<PointGuess>,
+    pub scalar_guesses: Vec<ScalarGuess>,
 }
 
 impl FromStr for Problem {

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -5,6 +5,7 @@ use super::{Component, Label};
 #[derive(Debug)]
 pub enum Instruction {
     DeclarePoint(DeclarePoint),
+    DeclareCircle(DeclareCircle),
     FixPointComponent(FixPointComponent),
     Vertical(Vertical),
     Horizontal(Horizontal),
@@ -12,6 +13,7 @@ pub enum Instruction {
     Parallel(Parallel),
     Perpendicular(Perpendicular),
     AngleLine(AngleLine),
+    CircleRadius(CircleRadius),
 }
 
 #[derive(Debug)]
@@ -24,6 +26,12 @@ pub struct Distance {
 pub struct Parallel {
     pub line0: (Label, Label),
     pub line1: (Label, Label),
+}
+
+#[derive(Debug)]
+pub struct CircleRadius {
+    pub circle: Label,
+    pub radius: f64,
 }
 
 #[derive(Debug)]
@@ -51,6 +59,11 @@ pub struct Horizontal {
 
 #[derive(Debug)]
 pub struct DeclarePoint {
+    pub label: Label,
+}
+
+#[derive(Debug)]
+pub struct DeclareCircle {
     pub label: Label,
 }
 

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -1,4 +1,7 @@
-use crate::textual::instruction::{AngleLine, Distance, Parallel, Perpendicular};
+use crate::textual::{
+    ScalarGuess,
+    instruction::{AngleLine, CircleRadius, DeclareCircle, Distance, Parallel, Perpendicular},
+};
 
 use super::{
     Component, Label, Point, PointGuess, Problem,
@@ -11,29 +14,61 @@ use winnow::{
     combinator::{alt, delimited, opt, separated},
     error::{ContextError, ErrMode},
     prelude::*,
+    stream::AsChar,
+    token::take_while,
 };
 
 pub fn parse_problem(i: &mut &str) -> WResult<Problem> {
     constraint_header.parse_next(i)?;
     let instructions: Vec<_> = separated(1.., parse_instruction, newline).parse_next(i)?;
     let mut inner_points = Vec::new();
+    let mut inner_circles = Vec::new();
     for instr in instructions.iter().flatten() {
         if let Instruction::DeclarePoint(dp) = instr {
             inner_points.push(dp.label.clone());
+        }
+        if let Instruction::DeclareCircle(dc) = instr {
+            inner_circles.push(dc.label.clone());
         }
     }
     newline.parse_next(i)?;
     newline.parse_next(i)?;
     ignore_ws(i);
     guesses_header.parse_next(i)?;
-    let point_guesses: Vec<_> = separated(1.., parse_point_guess, newline).parse_next(i)?;
+    let guesses: Vec<_> = separated(1.., parse_guess, newline).parse_next(i)?;
+    let (scalar_guesses, point_guesses): (Vec<_>, Vec<_>) = guesses.into_iter().fold(
+        (Vec::new(), Vec::new()),
+        |(mut scalars, mut points), guess| {
+            match guess {
+                Guess::Point(point_guess) => points.push(point_guess),
+                Guess::Scalar(scalar_guess) => scalars.push(scalar_guess),
+            };
+            (scalars, points)
+        },
+    );
     opt(newline).parse_next(i)?;
     ignore_ws(i);
     Ok(Problem {
         instructions: instructions.into_iter().flatten().collect(),
         inner_points,
+        inner_circles,
         point_guesses,
+        scalar_guesses,
     })
+}
+
+#[derive(Debug)]
+enum Guess {
+    Point(PointGuess),
+    Scalar(ScalarGuess),
+}
+
+pub fn parse_guess(i: &mut &str) -> WResult<Guess> {
+    alt((
+        parse_point_guess.map(Guess::Point),
+        parse_scalar_guess.map(Guess::Scalar),
+    ))
+    .parse_next(i)
 }
 
 // p roughly (0, 0)
@@ -50,6 +85,20 @@ pub fn parse_point_guess(i: &mut &str) -> WResult<PointGuess> {
     })
 }
 
+// c.radius roughly 4
+pub fn parse_scalar_guess(i: &mut &str) -> WResult<ScalarGuess> {
+    ignore_ws(i);
+    let label = parse_label(i)?;
+    ws.parse_next(i)?;
+    let _ = "roughly".parse_next(i)?;
+    ws.parse_next(i)?;
+    let guess = parse_number(i)?;
+    Ok(ScalarGuess {
+        scalar: label,
+        guess,
+    })
+}
+
 fn constraint_header(i: &mut &str) -> WResult<()> {
     ('#', ws, "constraints", newline).map(|_| ()).parse_next(i)
 }
@@ -60,6 +109,12 @@ fn guesses_header(i: &mut &str) -> WResult<()> {
 pub fn parse_declare_point(i: &mut &str) -> WResult<DeclarePoint> {
     ("point", ws, parse_label)
         .map(|(_, _, label)| DeclarePoint { label })
+        .parse_next(i)
+}
+
+pub fn parse_declare_circle(i: &mut &str) -> WResult<DeclareCircle> {
+    ("circle", ws, parse_label)
+        .map(|(_, _, label)| DeclareCircle { label })
         .parse_next(i)
 }
 
@@ -126,6 +181,13 @@ pub fn parse_parallel(i: &mut &str) -> WResult<Parallel> {
     Ok(Parallel { line0, line1 })
 }
 
+pub fn parse_circle_radius(i: &mut &str) -> WResult<CircleRadius> {
+    let _ = "radius".parse_next(i)?;
+    ignore_ws(i);
+    let (circle, _, radius) = inside_brackets((parse_label, commasep, parse_number_expr), i)?;
+    Ok(CircleRadius { circle, radius })
+}
+
 pub fn parse_perpendicular(i: &mut &str) -> WResult<Perpendicular> {
     let _ = "perpendicular".parse_next(i)?;
     ignore_ws(i);
@@ -176,6 +238,7 @@ fn parse_instruction(i: &mut &str) -> WResult<Vec<Instruction>> {
     ignore_ws(i);
     alt((
         parse_declare_point.map(Instruction::DeclarePoint).map(sv),
+        parse_declare_circle.map(Instruction::DeclareCircle).map(sv),
         parse_fix_point_component
             .map(Instruction::FixPointComponent)
             .map(sv),
@@ -186,6 +249,7 @@ fn parse_instruction(i: &mut &str) -> WResult<Vec<Instruction>> {
         parse_parallel.map(Instruction::Parallel).map(sv),
         parse_perpendicular.map(Instruction::Perpendicular).map(sv),
         parse_angle_line.map(Instruction::AngleLine).map(sv),
+        parse_circle_radius.map(Instruction::CircleRadius).map(sv),
     ))
     .parse_next(i)
 }
@@ -242,7 +306,7 @@ fn parse_fix_point_component(i: &mut &str) -> WResult<FixPointComponent> {
 }
 
 fn parse_label(i: &mut &str) -> WResult<Label> {
-    alphanumeric1
+    take_while(1.., (AsChar::is_alphanum))
         .map(|s: &str| Label(s.to_owned()))
         .parse_next(i)
 }

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -274,7 +274,7 @@ fn ignore_ws(i: &mut &str) {
 
 fn assign_point(i: &mut &str) -> WResult<Vec<Instruction>> {
     // p0 = (0, 0)
-    let label = parse_label(i)?;
+    let label = parse_label_opt_suffix(i)?;
     ignore_ws(i);
     '='.parse_next(i)?;
     ignore_ws(i);
@@ -319,6 +319,16 @@ fn parse_label(i: &mut &str) -> WResult<Label> {
     take_while(1.., AsChar::is_alphanum)
         .map(|s: &str| Label(s.to_owned()))
         .parse_next(i)
+}
+
+fn parse_label_opt_suffix(i: &mut &str) -> WResult<Label> {
+    let mut label = parse_label(i)?;
+    let suffix = opt(('.', parse_label)).parse_next(i)?;
+    if let Some((a, b)) = suffix {
+        label.0.push(a);
+        label.0.push_str(&b.0);
+    }
+    Ok(label)
 }
 
 pub fn parse_point(input: &mut &str) -> WResult<Point> {

--- a/test_cases/circle/problem.txt
+++ b/test_cases/circle/problem.txt
@@ -3,7 +3,7 @@ point p
 circle a
 radius(a, 40)
 p = (5, 5)
-a.center = (0, 0)
+a.center = (0.1, 0.2)
 
 # guesses
 p roughly (4, 3)

--- a/test_cases/circle/problem.txt
+++ b/test_cases/circle/problem.txt
@@ -1,0 +1,8 @@
+# constraints
+point p
+circle a
+
+# guesses
+p roughly (4, 3)
+a.center roughly (0.1, 0.1)
+a.radius roughly 39

--- a/test_cases/circle/problem.txt
+++ b/test_cases/circle/problem.txt
@@ -4,5 +4,5 @@ circle a
 
 # guesses
 p roughly (4, 3)
-a.center roughly (0.1, 0.1)
+a.center roughly (0.1, 0.2)
 a.radius roughly 39

--- a/test_cases/circle/problem.txt
+++ b/test_cases/circle/problem.txt
@@ -1,6 +1,9 @@
 # constraints
 point p
 circle a
+radius(a, 40)
+p = (5, 5)
+a.center = (0, 0)
 
 # guesses
 p roughly (4, 3)


### PR DESCRIPTION
This is a (relatively) big PR.

Firstly, in the core `ezpz` library, we add support for constraints on circles. Only one constraint is added here, constraining a circle's radius to some fixed length. But we do allow the existing "fix this point" constraint to work on a circle's center.

Then, in the text representation and the ezpz CLI (which are used for testing, debugging and benchmarking the core library), we add support for:

1. declaring circles (e.g. `circle a`, similar to the existing pattern `point q`)
2. displaying circles in the CLI's text output, or asserting them in unit tests.
3. support for specifying the circle's radius or center as a constraint.

Here's an example of an ezpz text file showing the new circles, their constraints, and their outputs:

<img width="869" height="648" alt="Screenshot 2025-09-03 at 8 29 08 PM" src="https://github.com/user-attachments/assets/53c683f7-ec90-49b2-b7e0-dccf708c9291" />