### PR TITLE
Add circle center points to the gnuplot output

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,3 +60,9 @@ fmt-check:
 # Probably in ~/.cargo/bin/ezpz
 install:
     cargo install --path ezpz-cli
+
+# Install the ezpz CLI.
+# The output text will tell you where it got installed.
+# Probably in ~/.cargo/bin/ezpz
+@reinstall:
+    cargo install --path ezpz-cli --quiet --offline

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -35,9 +35,9 @@ fn circle() {
     let circle_a = solved.get_circle("a").unwrap();
     // From the problem:
     // circle a
-    // radius(a, 40)
+    // radius(a, 3.4)
     // a.center = (0.1, 0.2)
-    assert_nearly_eq(circle_a.radius, 40.0);
+    assert_nearly_eq(circle_a.radius, 3.4);
     assert_points_eq(circle_a.center, Point { x: 0.1, y: 0.2 });
 }
 

--- a/test_cases/circle/problem.txt
+++ b/test_cases/circle/problem.txt
@@ -1,7 +1,7 @@
 # constraints
 point p
 circle a
-radius(a, 40)
+radius(a, 3.4)
 p = (5, 5)
 a.center = (0.1, 0.2)
 


### PR DESCRIPTION
In https://github.com/KittyCAD/ezpz/pull/62 I added circular geometry, and in this PR I've updated the gnuplot integration to display the circle's center. For example, this ezpz file:

```
# constraints
point p
circle a
radius(a, 3.4)
p = (5, 5)
a.center = (0.1, 0.2)

# guesses
p roughly (4, 3)
a.center roughly (0.1, 0.2)
a.radius roughly 39
```

generates this visualization:

<img width="754" height="693" alt="Screenshot 2025-09-03 at 9 31 45 PM" src="https://github.com/user-attachments/assets/b6b7e52b-e744-4630-b21c-32bb70d38e57" />

