### PR TITLE
feat: add codspeed for continuous performance testing

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,24 @@
+name: CodSpeed
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
+        with:
+          channel: stable
+          cache-target: release
+          bins: cargo-codspeed
+      - run: cargo codspeed build
+      - uses: CodSpeedHQ/action@v3
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "2.0.14"
 winnow = { version = "0.7.13" }
 
 [dev-dependencies]
-criterion = "0.7.0"
+criterion = { package = "codspeed-criterion-compat", version = "2.0.0" }
 
 [[bench]]
 name = "solver_bench"


### PR DESCRIPTION
## Summary
- Integrated CodSpeed for continuous performance testing using criterion.rs compatibility layer
- Added GitHub Actions workflow for automated benchmark execution on pushes and pull requests
- Maintained full compatibility with existing benchmark suite

## Implementation Details
- Updated `kcl-ezpz/Cargo.toml` to use `codspeed-criterion-compat` instead of direct criterion dependency
- Created `.github/workflows/codspeed.yml` with proper Ubuntu 22.04+ runner and cargo-codspeed setup
- All existing benchmarks (solve_tiny, solve_two_rectangles, solve_massive, etc.) remain unchanged and functional

## Next Steps
- Configure CODSPEED_TOKEN secret in repository settings
- Merge to enable continuous performance monitoring on all future PRs
- Monitor performance regressions and improvements through CodSpeed dashboard