### PR TITLE
Add line-is-tangent-to-circle constraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,7 @@ name = "kcl-ezpz"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "euler",
  "faer",
  "getrandom 0.2.16",
  "indexmap",

--- a/justfile
+++ b/justfile
@@ -61,9 +61,7 @@ fmt-check:
 install:
     cargo install --path ezpz-cli
 
-# Install the ezpz CLI.
-# The output text will tell you where it got installed.
-# Probably in ~/.cargo/bin/ezpz
+# Like `install` but faster.
 @reinstall:
     cargo install --path ezpz-cli --quiet --offline
 

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/KittyCAD/ezpz"
 license = "MIT"
 
 [dependencies]
+euler = "0.4.1"
 faer = "0.22.6"
 getrandom = { version = "0.2.16", features = ["js"] }
 indexmap = "2.11.0"

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -279,8 +279,8 @@ impl Constraint {
                 let dr_dx1 = (d.x * cross_term + (-y0 + yc) * mag_v_sq) / mag_v_cubed;
                 let dr_dy1 = ((x0 - xc) * mag_v_sq + d.y * cross_term) / mag_v_cubed;
 
-                let dr_dxc = (y0 - y1) / mag_v + (y0 - y1).powi(2);
-                let dr_dyc = (-x0 + x1) / mag_v + (y0 - y1).powi(2);
+                let dr_dxc = (y0 - y1) / mag_v;
+                let dr_dyc = (-x0 + x1) / mag_v;
 
                 let dr_dr = -1.0;
 

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -574,9 +574,11 @@ fn euclidean_distance_line(line: ((f64, f64), (f64, f64))) -> f64 {
 }
 
 fn cross(p0: (f64, f64), p1: (f64, f64)) -> f64 {
-    p0.0 * p1.1 - p0.1 * p1.0
+    cross_vec(DVec2::new(p0.0, p0.1), DVec2::new(p1.0, p1.1))
 }
 
+/// <https://stackoverflow.com/questions/243945/calculating-a-2d-vectors-cross-product>
+#[inline(always)]
 fn cross_vec(v: DVec2, w: DVec2) -> f64 {
     v.x * w.y - v.y * w.x
 }

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -8,6 +8,8 @@ use crate::{EPSILON, datatypes::*, id::Id, solver::Layout};
 pub enum Constraint {
     /// This line must be tangent to the circle
     /// (i.e. touches its perimeter in exactly one place)
+    /// Note this constraint is directional: making circle C
+    /// tangent to PQ will produce a different solution to QP.
     LineTangentToCircle(LineSegment, Circle),
     /// These two points should be a given distance apart.
     Distance(DatumPoint, DatumPoint, f64),

--- a/kcl-ezpz/src/datatypes.rs
+++ b/kcl-ezpz/src/datatypes.rs
@@ -77,6 +77,16 @@ impl LineSegment {
     pub fn new(p0: DatumPoint, p1: DatumPoint) -> Self {
         Self { p0, p1 }
     }
+
+    /// Get all IDs of all variables, i.e. p0.x, p0.y, p1.x, p1.y
+    pub fn all_variables(&self) -> [Id; 4] {
+        [
+            self.p0.id_x(),
+            self.p0.id_y(),
+            self.p1.id_x(),
+            self.p1.id_y(),
+        ]
+    }
 }
 
 /// A circle.
@@ -84,6 +94,13 @@ impl LineSegment {
 pub struct Circle {
     pub center: DatumPoint,
     pub radius: DatumDistance,
+}
+
+impl Circle {
+    /// Get all IDs of all variables, i.e. center components and radius.
+    pub fn all_variables(&self) -> [Id; 3] {
+        [self.center.id_x(), self.center.id_y(), self.radius.id]
+    }
 }
 
 /// Arc on the perimeter of a circle.

--- a/kcl-ezpz/src/solver.rs
+++ b/kcl-ezpz/src/solver.rs
@@ -221,6 +221,10 @@ impl<'c> NonlinearSystem for Model<'c> {
 
             for jacobian_row in jacobian_rows {
                 let row = row_num;
+                // eprintln!(
+                //     "Row {row} ({}): {jacobian_row:?}",
+                //     constraint.constraint_kind()
+                // );
                 row_num += 1;
                 for jacobian_var in jacobian_row {
                     let col = self.layout.index_of(jacobian_var.id);

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -63,7 +63,9 @@ fn circle_tangent() {
     assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 3.0 });
     assert_points_eq(solved.get_point("q").unwrap(), Point { x: 5.0, y: 3.0 });
     let circle_a = solved.get_circle("a").unwrap();
-    assert_points_eq(circle_a.center, Point { x: 2.5, y: 1.5 });
+    // The circle could either be above the p-q line (i.e. y is 4.5)
+    // or below it (i.e. y is 1.5)
+    assert_nearly_eq((circle_a.center.y - 3.0).abs(), 1.5);
 }
 
 #[test]

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -55,6 +55,9 @@ fn circle_center() {
 
 #[test]
 fn circle_tangent() {
+    // There's two possible ways to put the circle, either at y=4.5 or y=1.5
+    // Because the tangent constraint is directional, using PQ will always put it at
+    // y=4.5. We test the other solution in the `circle_tangent_other_dir` test.
     let txt = include_str!("../../test_cases/circle_tangent/problem.txt");
     let problem = parse_problem(txt);
     assert_eq!(problem.points(), vec!["p", "q"]);
@@ -63,9 +66,22 @@ fn circle_tangent() {
     assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 3.0 });
     assert_points_eq(solved.get_point("q").unwrap(), Point { x: 5.0, y: 3.0 });
     let circle_a = solved.get_circle("a").unwrap();
-    // The circle could either be above the p-q line (i.e. y is 4.5)
-    // or below it (i.e. y is 1.5)
-    assert_nearly_eq((circle_a.center.y - 3.0).abs(), 1.5);
+    assert_nearly_eq(circle_a.center.y, 4.5);
+}
+
+#[test]
+fn circle_tangent_other_dir() {
+    // Just like `circle_tangent` but using line QP instead of PQ, to test the
+    // other case of tangent direction.
+    let txt = include_str!("../../test_cases/circle_tangent_other_dir/problem.txt");
+    let problem = parse_problem(txt);
+    assert_eq!(problem.points(), vec!["p", "q"]);
+    assert_eq!(problem.circles(), vec!["a"]);
+    let solved = problem.to_constraint_system().unwrap().solve().unwrap();
+    assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 3.0 });
+    assert_points_eq(solved.get_point("q").unwrap(), Point { x: 5.0, y: 3.0 });
+    let circle_a = solved.get_circle("a").unwrap();
+    assert_nearly_eq(circle_a.center.y, 1.5);
 }
 
 #[test]

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -54,6 +54,19 @@ fn circle_center() {
 }
 
 #[test]
+fn circle_tangent() {
+    let txt = include_str!("../../test_cases/circle_tangent/problem.txt");
+    let problem = parse_problem(txt);
+    assert_eq!(problem.points(), vec!["p", "q"]);
+    assert_eq!(problem.circles(), vec!["a"]);
+    let solved = problem.to_constraint_system().unwrap().solve().unwrap();
+    assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 3.0 });
+    assert_points_eq(solved.get_point("q").unwrap(), Point { x: 5.0, y: 3.0 });
+    let circle_a = solved.get_circle("a").unwrap();
+    assert_points_eq(circle_a.center, Point { x: 2.5, y: 1.5 });
+}
+
+#[test]
 fn rectangle() {
     let txt = include_str!("../../test_cases/two_rectangles/problem.txt");
     let problem = Problem::from_str(txt).unwrap();

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -24,6 +24,7 @@ use crate::textual::instruction::FixPointComponent;
 use crate::textual::instruction::Horizontal;
 use crate::textual::instruction::Parallel;
 use crate::textual::instruction::Perpendicular;
+use crate::textual::instruction::Tangent;
 use crate::textual::instruction::Vertical;
 use crate::textual::{Circle, Point};
 
@@ -156,6 +157,26 @@ impl Problem {
                             radius: radius_id,
                         },
                         *radius,
+                    ));
+                }
+                Instruction::Tangent(Tangent {
+                    circle,
+                    line_p0,
+                    line_p1,
+                }) => {
+                    let circ = &circle.0;
+                    let center_id = datum_point_for_label(&Label(format!("{circ}.center")))?;
+                    let radius_id = datum_distance_for_label(&Label(format!("{circ}.radius")))?;
+                    let line = LineSegment {
+                        p0: datum_point_for_label(line_p0)?,
+                        p1: datum_point_for_label(line_p1)?,
+                    };
+                    constraints.push(Constraint::LineTangentToCircle(
+                        line,
+                        datatypes::Circle {
+                            center: center_id,
+                            radius: radius_id,
+                        },
                     ));
                 }
                 Instruction::FixPointComponent(FixPointComponent {

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -14,6 +14,7 @@ pub enum Instruction {
     Perpendicular(Perpendicular),
     AngleLine(AngleLine),
     CircleRadius(CircleRadius),
+    Tangent(Tangent),
     FixCenterPointComponent(FixCenterPointComponent),
 }
 
@@ -33,6 +34,13 @@ pub struct Parallel {
 pub struct CircleRadius {
     pub circle: Label,
     pub radius: f64,
+}
+
+#[derive(Debug)]
+pub struct Tangent {
+    pub circle: Label,
+    pub line_p0: Label,
+    pub line_p1: Label,
 }
 
 #[derive(Debug)]

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -2,7 +2,7 @@ use crate::textual::{
     ScalarGuess,
     instruction::{
         AngleLine, CircleRadius, DeclareCircle, Distance, FixCenterPointComponent, Parallel,
-        Perpendicular,
+        Perpendicular, Tangent,
     },
 };
 
@@ -201,6 +201,20 @@ pub fn parse_circle_radius(i: &mut &str) -> WResult<CircleRadius> {
     Ok(CircleRadius { circle, radius })
 }
 
+pub fn parse_tangent(i: &mut &str) -> WResult<Tangent> {
+    let _ = "tangent".parse_next(i)?;
+    ignore_ws(i);
+    let (line_p0, _, line_p1, _, circle) = inside_brackets(
+        (parse_label, commasep, parse_label, commasep, parse_label),
+        i,
+    )?;
+    Ok(Tangent {
+        circle,
+        line_p0,
+        line_p1,
+    })
+}
+
 pub fn parse_perpendicular(i: &mut &str) -> WResult<Perpendicular> {
     let _ = "perpendicular".parse_next(i)?;
     ignore_ws(i);
@@ -266,6 +280,7 @@ fn parse_instruction(i: &mut &str) -> WResult<Vec<Instruction>> {
         parse_perpendicular.map(Instruction::Perpendicular).map(sv),
         parse_angle_line.map(Instruction::AngleLine).map(sv),
         parse_circle_radius.map(Instruction::CircleRadius).map(sv),
+        parse_tangent.map(Instruction::Tangent).map(sv),
     ))
     .parse_next(i)
 }

--- a/test_cases/circle_tangent/problem.txt
+++ b/test_cases/circle_tangent/problem.txt
@@ -1,0 +1,15 @@
+# constraints
+point p
+point q
+circle a
+radius(a, 1.5)
+p = (0, 3)
+q = (5, 3)
+tangent(p, q, a)
+a.center.x = 2.5
+
+# guesses
+p roughly (4, 3)
+q roughly (4, 3.1)
+a.center roughly (0.1, 0.2)
+a.radius roughly 39

--- a/test_cases/circle_tangent/problem.txt
+++ b/test_cases/circle_tangent/problem.txt
@@ -9,7 +9,7 @@ tangent(p, q, a)
 a.center.x = 2.5
 
 # guesses
-p roughly (4, 3)
-q roughly (4, 3.1)
-a.center roughly (0.1, 0.2)
-a.radius roughly 39
+p roughly (0.1, 3.1)
+q roughly (4.9, 2.9)
+a.center roughly (2.5, 6)
+a.radius roughly 2

--- a/test_cases/circle_tangent_other_dir/problem.txt
+++ b/test_cases/circle_tangent_other_dir/problem.txt
@@ -5,7 +5,7 @@ circle a
 radius(a, 1.5)
 p = (0, 3)
 q = (5, 3)
-tangent(p, q, a)
+tangent(q, p, a)
 a.center.x = 2.5
 
 # guesses


### PR DESCRIPTION
Add a new constraint. Here's an example:

```
# constraints
point p
point q
circle a
radius(a, 1.5)
p = (0, 3)
q = (5, 3)
tangent(p, q, a)
a.center.x = 2.5

# guesses
p roughly (4, 3)
q roughly (4, 3.1)
a.center roughly (0.1, 0.2)
a.radius roughly 39
```

is solved as this:

<img width="754" height="693" alt="Screenshot 2025-09-04 at 10 32 28 PM" src="https://github.com/user-attachments/assets/3fb323cc-6f7e-4e94-b83e-791a726a83d7" />

Note that the tangent constraint is directional. If you change it from PQ to QP, then there's a different solution.

<img width="2894" height="1096" alt="Screenshot 2025-09-05 at 10 11 32 AM" src="https://github.com/user-attachments/assets/443f0360-7f5b-441d-ad92-02fcdb2c13d0" />

This is probably not what users want or expect, so we should fix it in a follow-up. 