### PR TITLE
Use consistent vector/point type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,6 @@ name = "kcl-ezpz"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "euler",
  "faer",
  "getrandom 0.2.16",
  "indexmap",

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/KittyCAD/ezpz"
 license = "MIT"
 
 [dependencies]
-euler = "0.4.1"
 faer = "0.22.6"
 getrandom = { version = "0.2.16", features = ["js"] }
 indexmap = "2.11.0"

--- a/kcl-ezpz/src/lib.rs
+++ b/kcl-ezpz/src/lib.rs
@@ -20,6 +20,7 @@ mod solver;
 mod tests;
 /// Parser for textual representation of these problems.
 pub mod textual;
+mod vector;
 
 const EPSILON: f64 = 0.001;
 

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -8,7 +8,7 @@ pub use executor::Outcome;
 use instruction::Instruction;
 use winnow::Parser;
 
-use crate::textual::parser::parse_problem;
+use crate::{textual::parser::parse_problem, vector::V};
 
 #[derive(Debug, PartialEq)]
 pub struct PointGuess {
@@ -60,7 +60,7 @@ impl std::fmt::Display for Point {
 impl Point {
     #[allow(dead_code)]
     pub(crate) fn euclidean_distance(&self, r: Point) -> f64 {
-        crate::constraints::euclidean_distance((self.x, self.y), (r.x, r.y))
+        V::new(self.x, self.y).euclidean_distance(V::new(r.x, r.y))
     }
 }
 

--- a/kcl-ezpz/src/vector.rs
+++ b/kcl-ezpz/src/vector.rs
@@ -1,0 +1,50 @@
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+pub(crate) struct V {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl V {
+    #[inline(always)]
+    pub fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    #[inline(always)]
+    pub fn magnitude(&self) -> f64 {
+        (self.x.powi(2) + self.y.powi(2)).sqrt()
+    }
+
+    #[inline(always)]
+    pub fn magnitude_squared(&self) -> f64 {
+        self.x.powi(2) + self.y.powi(2)
+    }
+
+    #[inline(always)]
+    pub fn dot(&self, rhs: &Self) -> f64 {
+        self.x * rhs.x + self.y * rhs.y
+    }
+
+    #[inline(always)]
+    pub fn euclidean_distance(self, rhs: Self) -> f64 {
+        let d = self - rhs;
+        d.magnitude()
+    }
+
+    /// <https://stackoverflow.com/questions/243945/calculating-a-2d-vectors-cross-product>
+    #[inline(always)]
+    pub fn cross_2d(&self, rhs: &Self) -> f64 {
+        self.x * rhs.y - self.y * rhs.x
+    }
+}
+
+impl std::ops::Sub<Self> for V {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+        }
+    }
+}


### PR DESCRIPTION
I've made an alias `V` for "2D vector of f64s". Right now it refers to `nalgebra::Vector2<f64>` but we can easily change it in the future if we want to use a different crate, or handwritten impl.

I benchmarked this against both docs.rs/cgmath and docs.rs/nalgebra, and they were both slower. Katie suggests it's because rustc can't inline across crates.

Regardless, I think having a tiny, handwritten, mostly-single-lines-of-code implementation will make it easier for rustc to optimize this code.