### PR TITLE
Add Tikhonov Regularization

### DIFF
--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -184,6 +184,20 @@ s roughly (5, 6)
     );
 }
 
+#[test]
+fn underdetermined_lines() {
+    // This should solve for a horizontal line from (0,0) to (4,0), then
+    // a vertical line from (4,0) to (4,4). Note that the length of the second
+    // line is not specified; we're relying on regularisation to push our solution
+    // towards its start point.
+    let txt = include_str!("../../test_cases/underdetermined_lines/problem.txt");
+    let problem = Problem::from_str(txt).unwrap();
+    let solved = problem.to_constraint_system().unwrap().solve().unwrap();
+    assert_points_eq(solved.get_point("p0").unwrap(), Point { x: 0.0, y: 0.0 });
+    assert_points_eq(solved.get_point("p1").unwrap(), Point { x: 4.0, y: 0.0 });
+    assert_points_eq(solved.get_point("p2").unwrap(), Point { x: 4.0, y: 4.0 });
+}
+
 #[track_caller]
 fn assert_points_eq(l: Point, r: Point) {
     let dist = l.euclidean_distance(r);

--- a/test_cases/underdetermined_lines/problem.txt
+++ b/test_cases/underdetermined_lines/problem.txt
@@ -1,0 +1,13 @@
+# constraints
+point p0
+point p1
+point p2
+p0 = (0, 0)
+horizontal(p0, p1)
+distance(p0, p1, 4)
+vertical(p1, p2)
+
+# guesses
+p0 roughly (0, 0)
+p1 roughly (0, 3.2)
+p2 roughly (4, 4)


### PR DESCRIPTION
Addresses: https://github.com/KittyCAD/ezpz/issues/7

Also worth noting that the `underdetermined_lines` inadvertently tests the sharing of vertices between lines, and that seems to work in this very simple case - which I guess stacks since we added in partial derivative accumulation.