### PR TITLE
Improve tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "ezpz"
+name = "ezpz-cli"
 version = "0.1.0"
 dependencies = [
  "clap",

--- a/ezpz-cli/Cargo.toml
+++ b/ezpz-cli/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
-name = "ezpz"
+name = "ezpz-cli"
 version = "0.1.0"
 edition = "2024"
 repository = "https://github.com/KittyCAD/ezpz"
 description = "CLI for using the ezpz constraint solver"
 license = "MIT"
+
+[[bin]]
+path = "src/main.rs"
+name = "ezpz"
 
 [dependencies]
 clap = { version = "4.5.45", features = ["derive"] }

--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -374,3 +374,29 @@ fn read_problem(cli: &Cli) -> Result<String, String> {
         .map_err(|e| e.to_string())?;
     Ok(constraint_txt)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn test_tiny() {
+        let out = Command::new("cargo")
+            .args([
+                "run",
+                "--quiet",
+                "--",
+                "-f",
+                "../test_cases/tiny/problem.txt",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
+            .wait_with_output()
+            .unwrap();
+        assert!(out.status.success());
+        let stdout = String::from_utf8(out.stdout).unwrap();
+        assert!(stdout.contains("Problem size: 4 rows, 4 vars"));
+    }
+}

--- a/kcl-ezpz/src/solver.rs
+++ b/kcl-ezpz/src/solver.rs
@@ -15,7 +15,7 @@ const REGULARIZATION_LAMBDA: f64 = 1e-9;
 #[derive(Debug, Clone, Copy)]
 pub struct Config {
     /// Use Tikhonov regularization to solve underdetermined systems.
-    regularization_enabled: bool,
+    pub regularization_enabled: bool,
 }
 
 impl Default for Config {

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -10,6 +10,13 @@ fn run(test_case: &str) -> Outcome {
     system.solve().unwrap()
 }
 
+fn run_with_config(test_case: &str, config: Config) -> Outcome {
+    let txt = std::fs::read_to_string(format!("../test_cases/{test_case}/problem.txt")).unwrap();
+    let problem = parse_problem(&txt);
+    let system = problem.to_constraint_system().unwrap();
+    system.solve_with_config(config).unwrap()
+}
+
 fn parse_problem(txt: &str) -> Problem {
     match Problem::from_str(txt) {
         Ok(x) => x,
@@ -40,6 +47,18 @@ fn underconstrained() {
 #[test]
 fn tiny() {
     let solved = run("tiny");
+    assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 0.0 });
+    assert_points_eq(solved.get_point("q").unwrap(), Point { x: 0.0, y: 0.0 });
+}
+
+#[test]
+fn tiny_no_regularization() {
+    let solved = run_with_config(
+        "tiny",
+        Config {
+            regularization_enabled: false,
+        },
+    );
     assert_points_eq(solved.get_point("p").unwrap(), Point { x: 0.0, y: 0.0 });
     assert_points_eq(solved.get_point("q").unwrap(), Point { x: 0.0, y: 0.0 });
 }


### PR DESCRIPTION
* Test the non-regularized path
* Test the CLI succeeds
* Rename ezpz package to ezpz-cli (the binary is still named ezpz)