### PR TITLE
Support circular arcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 flamegraph.svg
 lcov.info
 .vscode/
+foo.png

--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -286,6 +286,7 @@ fn print_output((outcome, duration): &(Outcome, Duration), show_points: bool) {
         lints,
         points,
         circles,
+        arcs,
         num_vars,
         num_eqs,
     } = outcome;
@@ -302,6 +303,17 @@ fn print_output((outcome, duration): &(Outcome, Duration), show_points: bool) {
         for (label, kcl_ezpz::textual::Circle { radius, center }) in circles {
             let Point { x, y } = center;
             println!("\t{label}: center = ({x:.2}, {y:.2}), radius = {radius:.2}",);
+        }
+        println!("Arcs:");
+        for (label, kcl_ezpz::textual::Arc { a, b, center }) in arcs {
+            let Point { x, y } = center;
+            let ax = a.x;
+            let ay = a.y;
+            let bx = b.x;
+            let by = b.y;
+            println!(
+                "\t{label}: center = ({x:.2}, {y:.2}), a = ({ax:.2}, {ay:.2}), b = ({bx:.2}, {by:.2})",
+            );
         }
     }
 }

--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ install:
 
 # Like `install` but faster.
 @reinstall:
-    cargo install --path ezpz-cli --quiet --offline
+    cargo install --path ezpz-cli --quiet --offline --force
 
 # Create a new test case
 new-test name:

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -94,13 +94,15 @@ impl Constraint {
                 row0.extend(line0.all_variables());
                 row0.extend(line1.all_variables());
             }
-            Constraint::ArcRadius(arc, _radius) => {
-                row0.push(arc.center.id_x());
-                row0.push(arc.center.id_y());
-                row0.push(arc.a.id_x());
-                row0.push(arc.a.id_y());
-                row0.push(arc.b.id_x());
-                row0.push(arc.b.id_y());
+            Constraint::ArcRadius(arc, radius) => {
+                // This is really just equivalent to 2 constraints,
+                // distance(center, a) and distance(center, b).
+                let constraints = (
+                    Constraint::Distance(arc.center, arc.a, *radius),
+                    Constraint::Distance(arc.center, arc.b, *radius),
+                );
+                constraints.0.nonzeroes(row0, row1);
+                constraints.1.nonzeroes(row1, row0);
             }
         }
     }

--- a/kcl-ezpz/src/datatypes.rs
+++ b/kcl-ezpz/src/datatypes.rs
@@ -128,7 +128,8 @@ impl Circle {
 }
 
 /// Arc on the perimeter of a circle.
-#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct CircularArc {
     /// Center of the circle
     pub center: DatumPoint,

--- a/kcl-ezpz/src/lib.rs
+++ b/kcl-ezpz/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 pub mod textual;
 mod vector;
 
-const EPSILON: f64 = 1e-5;
+const EPSILON: f64 = 1e-4;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -211,6 +211,11 @@ fn underdetermined_lines() {
 }
 
 #[test]
+fn arc_radius() {
+    let _solved = run("arc_radius");
+}
+
+#[test]
 fn lints() {
     let txt = "# constraints
 point p

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -212,7 +212,11 @@ fn underdetermined_lines() {
 
 #[test]
 fn arc_radius() {
-    let _solved = run("arc_radius");
+    let solved = run("arc_radius");
+    let arc = solved.get_arc("a").unwrap();
+    assert_points_eq(arc.center, Point { x: 0.0, y: 0.0 });
+    assert_points_eq(arc.a, Point { x: 0.0, y: 5.0 });
+    assert_points_eq(arc.b, Point { x: 5.0, y: 0.0 });
 }
 
 #[test]

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -53,6 +53,13 @@ pub struct Circle {
     pub center: Point,
 }
 
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct Arc {
+    pub a: Point,
+    pub b: Point,
+    pub center: Point,
+}
+
 impl std::fmt::Display for Point {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "({},{})", self.x, self.y)

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -28,6 +28,7 @@ pub struct Problem {
     pub instructions: Vec<Instruction>,
     pub inner_points: Vec<Label>,
     pub inner_circles: Vec<Label>,
+    pub inner_arcs: Vec<Label>,
     pub point_guesses: Vec<PointGuess>,
     pub scalar_guesses: Vec<ScalarGuess>,
 }

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -79,15 +79,15 @@ impl Problem {
                     label: center_label,
                 });
             };
-            let p_label = format!("{}.p", arc.0);
-            let Some(p_guess) = guessmap_points.remove(&p_label) else {
-                return Err(Error::MissingGuess { label: p_label });
+            let a_label = format!("{}.a", arc.0);
+            let Some(a_guess) = guessmap_points.remove(&a_label) else {
+                return Err(Error::MissingGuess { label: a_label });
             };
-            let q_label = format!("{}.q", arc.0);
-            let Some(q_guess) = guessmap_points.remove(&q_label) else {
-                return Err(Error::MissingGuess { label: q_label });
+            let b_label = format!("{}.b", arc.0);
+            let Some(b_guess) = guessmap_points.remove(&b_label) else {
+                return Err(Error::MissingGuess { label: b_label });
             };
-            initial_guesses.push_arc(&mut id_generator, p_guess, q_guess, center_guess);
+            initial_guesses.push_arc(&mut id_generator, a_guess, b_guess, center_guess);
         }
         if !guessmap_points.is_empty() {
             let labels: Vec<String> = guessmap_points.keys().cloned().collect();
@@ -130,34 +130,25 @@ impl Problem {
                 .position(|arc| format!("{}.center", arc.0) == label.0.as_str())
             {
                 let center = initial_guesses.get_arc_ids(arc_id).center;
-                return Ok(DatumPoint {
-                    x_id: center.x,
-                    y_id: center.y,
-                });
+                return Ok(center.into());
             }
             // Is it an arc's `p` point?
             if let Some(arc_id) = self
                 .inner_arcs
                 .iter()
-                .position(|arc| format!("{}.p", arc.0) == label.0.as_str())
+                .position(|arc| format!("{}.a", arc.0) == label.0.as_str())
             {
-                let p = initial_guesses.get_arc_ids(arc_id).p;
-                return Ok(DatumPoint {
-                    x_id: p.x,
-                    y_id: p.y,
-                });
+                let a = initial_guesses.get_arc_ids(arc_id).a;
+                return Ok(a.into());
             }
-            // Is it an arc's `q` point?
+            // Is it an arc's `b` point?
             if let Some(arc_id) = self
                 .inner_arcs
                 .iter()
-                .position(|arc| format!("{}.q", arc.0) == label.0.as_str())
+                .position(|arc| format!("{}.b", arc.0) == label.0.as_str())
             {
-                let q = initial_guesses.get_arc_ids(arc_id).q;
-                return Ok(DatumPoint {
-                    x_id: q.x,
-                    y_id: q.y,
-                });
+                let b = initial_guesses.get_arc_ids(arc_id).b;
+                return Ok(b.into());
             }
             // Well, it wasn't any of the geometries we recognize.
             Err(Error::UndefinedPoint {

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -71,6 +71,24 @@ impl Problem {
                 radius_guess,
             );
         }
+        for arc in &self.inner_arcs {
+            // Each arc should have a guess for its 3 points (p, q, and center).
+            let center_label = format!("{}.center", arc.0);
+            let Some(center_guess) = guessmap_points.remove(&center_label) else {
+                return Err(Error::MissingGuess {
+                    label: center_label,
+                });
+            };
+            let p_label = format!("{}.p", arc.0);
+            let Some(p_guess) = guessmap_points.remove(&p_label) else {
+                return Err(Error::MissingGuess { label: p_label });
+            };
+            let q_label = format!("{}.q", arc.0);
+            let Some(q_guess) = guessmap_points.remove(&q_label) else {
+                return Err(Error::MissingGuess { label: q_label });
+            };
+            initial_guesses.push_arc(&mut id_generator, p_guess, q_guess, center_guess);
+        }
         if !guessmap_points.is_empty() {
             let labels: Vec<String> = guessmap_points.keys().cloned().collect();
             return Err(Error::UnusedGuesses { labels });

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -124,6 +124,7 @@ impl Problem {
             match instr {
                 Instruction::DeclarePoint(_) => {}
                 Instruction::DeclareCircle(_) => {}
+                Instruction::DeclareArc(_) => {}
                 Instruction::CircleRadius(CircleRadius { circle, radius }) => {
                     let circ = &circle.0;
                     let center_id = datum_point_for_label(&Label(format!("{circ}.center")))?;

--- a/kcl-ezpz/src/textual/geometry_variables.rs
+++ b/kcl-ezpz/src/textual/geometry_variables.rs
@@ -2,7 +2,7 @@ use crate::{Id, IdGenerator, datatypes::DatumPoint, textual::Point};
 
 const VARS_PER_POINT: usize = 2;
 const VARS_PER_CIRCLE: usize = 3;
-const VARS_PER_ARC: usize = 6;
+pub const VARS_PER_ARC: usize = 6;
 
 /// Stores variables for different constrainable geometry.
 #[derive(Default, Clone, Debug)]
@@ -70,13 +70,13 @@ impl GeometryVariables {
 
     /// Add variables for a arc.
     /// Once you call this, you cannot push 2D points or circles anymore.
-    pub fn push_arc(&mut self, id_generator: &mut IdGenerator, p: Point, q: Point, center: Point) {
+    pub fn push_arc(&mut self, id_generator: &mut IdGenerator, a: Point, b: Point, center: Point) {
         self.num_arcs += 1;
         let c = center;
-        self.variables.push((id_generator.next_id(), p.x));
-        self.variables.push((id_generator.next_id(), p.y));
-        self.variables.push((id_generator.next_id(), q.x));
-        self.variables.push((id_generator.next_id(), q.y));
+        self.variables.push((id_generator.next_id(), a.x));
+        self.variables.push((id_generator.next_id(), a.y));
+        self.variables.push((id_generator.next_id(), b.x));
+        self.variables.push((id_generator.next_id(), b.y));
         self.variables.push((id_generator.next_id(), c.x));
         self.variables.push((id_generator.next_id(), c.y));
     }

--- a/kcl-ezpz/src/textual/geometry_variables.rs
+++ b/kcl-ezpz/src/textual/geometry_variables.rs
@@ -1,4 +1,4 @@
-use crate::{Id, IdGenerator, textual::Point};
+use crate::{Id, IdGenerator, datatypes::DatumPoint, textual::Point};
 
 const VARS_PER_POINT: usize = 2;
 const VARS_PER_CIRCLE: usize = 3;
@@ -103,16 +103,16 @@ impl GeometryVariables {
     /// Look up the variables for a given arc.
     pub fn get_arc_ids(&self, arc_id: usize) -> ArcVars {
         let start_of_arcs = VARS_PER_POINT * self.num_points;
-        let px = self.variables[start_of_arcs + VARS_PER_ARC * arc_id].0;
-        let py = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 1].0;
-        let p = PointVars { x: px, y: py };
-        let qx = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 2].0;
-        let qy = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 3].0;
-        let q = PointVars { x: qx, y: qy };
+        let ax = self.variables[start_of_arcs + VARS_PER_ARC * arc_id].0;
+        let ay = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 1].0;
+        let a = PointVars { x: ax, y: ay };
+        let bx = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 2].0;
+        let by = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 3].0;
+        let b = PointVars { x: bx, y: by };
         let cx = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 4].0;
         let cy = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 5].0;
         let center = PointVars { x: cx, y: cy };
-        ArcVars { p, q, center }
+        ArcVars { a, b, center }
     }
 }
 
@@ -121,13 +121,23 @@ pub struct PointVars {
     pub y: Id,
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<DatumPoint> for PointVars {
+    fn into(self) -> DatumPoint {
+        DatumPoint {
+            x_id: self.x,
+            y_id: self.y,
+        }
+    }
+}
+
 pub struct CircleVars {
     pub center: PointVars,
     pub radius: Id,
 }
 
 pub struct ArcVars {
-    pub p: PointVars,
-    pub q: PointVars,
+    pub a: PointVars,
+    pub b: PointVars,
     pub center: PointVars,
 }

--- a/kcl-ezpz/src/textual/geometry_variables.rs
+++ b/kcl-ezpz/src/textual/geometry_variables.rs
@@ -1,4 +1,4 @@
-use crate::{Id, IdGenerator};
+use crate::{Id, IdGenerator, textual::Point};
 
 const VARS_PER_POINT: usize = 2;
 const VARS_PER_CIRCLE: usize = 3;
@@ -70,21 +70,15 @@ impl GeometryVariables {
 
     /// Add variables for a arc.
     /// Once you call this, you cannot push 2D points or circles anymore.
-    pub fn push_arc(
-        &mut self,
-        id_generator: &mut IdGenerator,
-        p: (f64, f64),
-        q: (f64, f64),
-        center: (f64, f64),
-    ) {
+    pub fn push_arc(&mut self, id_generator: &mut IdGenerator, p: Point, q: Point, center: Point) {
         self.num_arcs += 1;
         let c = center;
-        self.variables.push((id_generator.next_id(), p.0));
-        self.variables.push((id_generator.next_id(), p.1));
-        self.variables.push((id_generator.next_id(), q.0));
-        self.variables.push((id_generator.next_id(), q.1));
-        self.variables.push((id_generator.next_id(), c.0));
-        self.variables.push((id_generator.next_id(), c.1));
+        self.variables.push((id_generator.next_id(), p.x));
+        self.variables.push((id_generator.next_id(), p.y));
+        self.variables.push((id_generator.next_id(), q.x));
+        self.variables.push((id_generator.next_id(), q.y));
+        self.variables.push((id_generator.next_id(), c.x));
+        self.variables.push((id_generator.next_id(), c.y));
     }
 
     /// Look up the variables for a given 2D point.

--- a/kcl-ezpz/src/textual/geometry_variables.rs
+++ b/kcl-ezpz/src/textual/geometry_variables.rs
@@ -5,7 +5,7 @@ const VARS_PER_CIRCLE: usize = 3;
 const VARS_PER_ARC: usize = 6;
 
 /// Stores variables for different constrainable geometry.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct GeometryVariables {
     /// List of variables, each with an ID and a value.
     // Layout of this vec:

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -6,6 +6,7 @@ use super::{Component, Label};
 pub enum Instruction {
     DeclarePoint(DeclarePoint),
     DeclareCircle(DeclareCircle),
+    DeclareArc(DeclareArc),
     FixPointComponent(FixPointComponent),
     Vertical(Vertical),
     Horizontal(Horizontal),
@@ -87,6 +88,11 @@ pub struct DeclarePoint {
 
 #[derive(Debug)]
 pub struct DeclareCircle {
+    pub label: Label,
+}
+
+#[derive(Debug)]
+pub struct DeclareArc {
     pub label: Label,
 }
 

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -105,7 +105,7 @@ pub struct FixPointComponent {
 
 #[derive(Debug)]
 pub struct FixCenterPointComponent {
-    pub circle: Label,
+    pub object: Label,
     pub center_component: Component,
     pub value: f64,
 }

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -17,6 +17,7 @@ pub enum Instruction {
     PointsCoincident(PointsCoincident),
     CircleRadius(CircleRadius),
     Tangent(Tangent),
+    ArcRadius(ArcRadius),
     FixCenterPointComponent(FixCenterPointComponent),
     LinesEqualLength(LinesEqualLength),
 }
@@ -44,6 +45,12 @@ pub struct Tangent {
     pub circle: Label,
     pub line_p0: Label,
     pub line_p1: Label,
+}
+
+#[derive(Debug)]
+pub struct ArcRadius {
+    pub arc_label: Label,
+    pub radius: f64,
 }
 
 #[derive(Debug)]

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -3,8 +3,9 @@ use crate::{
     textual::{
         ScalarGuess,
         instruction::{
-            AngleLine, CircleRadius, DeclareArc, DeclareCircle, Distance, FixCenterPointComponent,
-            LinesEqualLength, Parallel, Perpendicular, PointsCoincident, Tangent,
+            AngleLine, ArcRadius, CircleRadius, DeclareArc, DeclareCircle, Distance,
+            FixCenterPointComponent, LinesEqualLength, Parallel, Perpendicular, PointsCoincident,
+            Tangent,
         },
     },
 };
@@ -235,6 +236,13 @@ pub fn parse_tangent(i: &mut &str) -> WResult<Tangent> {
     })
 }
 
+pub fn parse_arc_radius(i: &mut &str) -> WResult<ArcRadius> {
+    let _ = "arc_radius".parse_next(i)?;
+    ignore_ws(i);
+    let (arc_label, _, radius) = inside_brackets((parse_label, commasep, parse_number), i)?;
+    Ok(ArcRadius { arc_label, radius })
+}
+
 pub fn parse_lines_equal_length(i: &mut &str) -> WResult<LinesEqualLength> {
     let _ = "lines_equal_length".parse_next(i)?;
     ignore_ws(i);
@@ -312,6 +320,7 @@ fn parse_instruction(i: &mut &str) -> WResult<Vec<Instruction>> {
         parse_angle_line.map(Instruction::AngleLine).map(sv),
         parse_circle_radius.map(Instruction::CircleRadius).map(sv),
         parse_tangent.map(Instruction::Tangent).map(sv),
+        parse_arc_radius.map(Instruction::ArcRadius).map(sv),
         parse_lines_equal_length
             .map(Instruction::LinesEqualLength)
             .map(sv),

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -403,7 +403,7 @@ fn parse_fix_center_point_component(i: &mut &str) -> WResult<FixCenterPointCompo
     )
         .map(
             |(label, _dot, component, _equals, value)| FixCenterPointComponent {
-                circle: label,
+                object: label,
                 center_component: component,
                 value,
             },

--- a/test_cases/arc_radius/problem.txt
+++ b/test_cases/arc_radius/problem.txt
@@ -3,6 +3,7 @@ point p
 arc a
 a.center.x = 0
 a.center.y = 0
+arc_radius(a, 5)
 
 # guesses
 p roughly (4, 3)

--- a/test_cases/arc_radius/problem.txt
+++ b/test_cases/arc_radius/problem.txt
@@ -1,6 +1,8 @@
 # constraints
 point p
 arc a
+a.center.x = 0
+a.center.y = 0
 
 # guesses
 p roughly (4, 3)

--- a/test_cases/arc_radius/problem.txt
+++ b/test_cases/arc_radius/problem.txt
@@ -1,0 +1,9 @@
+# constraints
+point p
+arc a
+
+# guesses
+p roughly (4, 3)
+a.center roughly (0.1, 0.2)
+a.p roughly (0, 4)
+a.q roughly (4, 0)

--- a/test_cases/arc_radius/problem.txt
+++ b/test_cases/arc_radius/problem.txt
@@ -7,5 +7,5 @@ a.center.y = 0
 # guesses
 p roughly (4, 3)
 a.center roughly (0.1, 0.2)
-a.p roughly (0, 4)
-a.q roughly (4, 0)
+a.a roughly (0, 4)
+a.b roughly (4, 0)


### PR DESCRIPTION
This PR:

1. Adds support for circular arcs in the ezpz CLI and text representation (these aren't used in production, they're just used for testing, debugging or experimenting with ezpz)
2. Adds a basic constraint, ArcRadius, which is equivalent to distance(arc.center, arc.a, dist) and distance(arc.center, arc.b, dist)
3. Adds a test with that constraint

This test problem:

```md
# constraints
point p
arc a
a.center.x = 0
a.center.y = 0
arc_radius(a, 5)

# guesses
p roughly (4, 3)
a.center roughly (0.1, 0.2)
a.a roughly (0, 4)
a.b roughly (4, 0)
```

correctly outputs this solution:

<img width="600" height="600" alt="foo" src="https://github.com/user-attachments/assets/5c2dac20-fa7a-4519-b353-5ba209f5350e" />

