### PR TITLE
just lint should include fuzzer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,18 +51,3 @@ jobs:
           - name: Run checks
             run: just fmt-check
 
-    check-fuzz:
-        name: cargo fuzz check
-        runs-on: ubuntu-latest-8-cores
-        steps:
-          - uses: actions/checkout@v4
-          - name: Install Rust
-            uses: dtolnay/rust-toolchain@nightly
-            with:
-                components: rustfmt
-          - uses: cargo-bins/cargo-binstall@main
-          - name: Install deps
-            run: cargo binstall cargo-fuzz
-          - name: Check fuzzer can build
-            run: cargo +nightly fuzz check --target x86_64-unknown-linux-gnu
-

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -13,7 +13,7 @@ fuzz_target!(|setup: Setup| {
         .map(|(i, v)| (Id::try_from(i).unwrap(), v))
         .collect();
     let constraints = &setup.constraints;
-    let _ = kcl_ezpz::solve(&constraints, guesses, Default::default());
+    let _ = kcl_ezpz::solve(constraints, guesses, Default::default());
 });
 
 #[derive(Debug, Arbitrary)]

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-clippy-flags := "--workspace --tests --benches --examples"
+clippy-flags := "--workspace --tests --benches --examples --all-targets"
 gen := "test_cases/massive_parallel_system/gen_big_problem.py"
 
 # Check most of CI, but locally.


### PR DESCRIPTION
This means we don't need a CI action to check the fuzzer compiled, that's now covered by "just lint".