### PR TITLE
Address nits in GeometryVariables

### DIFF
--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -111,7 +111,7 @@ impl Problem {
         let datum_point_for_label = |label: &Label| -> Result<DatumPoint, crate::Error> {
             // Is the point a single geometric point?
             if let Some(point_id) = self.inner_points.iter().position(|p| p == &label.0) {
-                let ids = initial_guesses.get_point_ids(point_id);
+                let ids = initial_guesses.point_ids(point_id);
                 return Ok(DatumPoint {
                     x_id: ids.x,
                     y_id: ids.y,
@@ -123,7 +123,7 @@ impl Problem {
                 .iter()
                 .position(|circ| format!("{}.center", circ.0) == label.0.as_str())
             {
-                let center = initial_guesses.get_circle_ids(circle_id).center;
+                let center = initial_guesses.circle_ids(circle_id).center;
                 return Ok(DatumPoint {
                     x_id: center.x,
                     y_id: center.y,
@@ -136,7 +136,7 @@ impl Problem {
                 .iter()
                 .position(|arc| format!("{}.center", arc.0) == label.0.as_str())
             {
-                let center = initial_guesses.get_arc_ids(arc_id).center;
+                let center = initial_guesses.arc_ids(arc_id).center;
                 return Ok(center.into());
             }
             // Is it an arc's `p` point?
@@ -145,7 +145,7 @@ impl Problem {
                 .iter()
                 .position(|arc| format!("{}.a", arc.0) == label.0.as_str())
             {
-                let a = initial_guesses.get_arc_ids(arc_id).a;
+                let a = initial_guesses.arc_ids(arc_id).a;
                 return Ok(a.into());
             }
             // Is it an arc's `b` point?
@@ -154,7 +154,7 @@ impl Problem {
                 .iter()
                 .position(|arc| format!("{}.b", arc.0) == label.0.as_str())
             {
-                let b = initial_guesses.get_arc_ids(arc_id).b;
+                let b = initial_guesses.arc_ids(arc_id).b;
                 return Ok(b.into());
             }
             // Well, it wasn't any of the geometries we recognize.
@@ -168,7 +168,7 @@ impl Problem {
                 .iter()
                 .position(|circ| format!("{}.radius", circ.0) == label.0.as_str())
             {
-                let ids = initial_guesses.get_circle_ids(circle_id);
+                let ids = initial_guesses.circle_ids(circle_id);
                 return Ok(DatumDistance { id: ids.radius });
             }
             Err(Error::UndefinedPoint {
@@ -230,7 +230,7 @@ impl Problem {
                     if let Some(point_id) =
                         self.inner_points.iter().position(|label| label == point)
                     {
-                        let ids = initial_guesses.get_point_ids(point_id);
+                        let ids = initial_guesses.point_ids(point_id);
                         let id = match component {
                             Component::X => ids.x,
                             Component::Y => ids.y,
@@ -240,7 +240,7 @@ impl Problem {
                         if let Some(circle_id) =
                             self.inner_circles.iter().position(|p| p.0 == circle_label)
                         {
-                            let center = initial_guesses.get_circle_ids(circle_id).center;
+                            let center = initial_guesses.circle_ids(circle_id).center;
                             let id = match component {
                                 Component::X => center.x,
                                 Component::Y => center.y,
@@ -262,7 +262,7 @@ impl Problem {
                     if let Some(circle_id) =
                         self.inner_circles.iter().position(|label| label == object)
                     {
-                        let center = initial_guesses.get_circle_ids(circle_id).center;
+                        let center = initial_guesses.circle_ids(circle_id).center;
                         let id = match center_component {
                             Component::X => center.x,
                             Component::Y => center.y,
@@ -272,7 +272,7 @@ impl Problem {
                     } else if let Some(arc_id) =
                         self.inner_arcs.iter().position(|label| label == object)
                     {
-                        let center = initial_guesses.get_arc_ids(arc_id).center;
+                        let center = initial_guesses.arc_ids(arc_id).center;
                         let id = match center_component {
                             Component::X => center.x,
                             Component::Y => center.y,

--- a/kcl-ezpz/src/textual/geometry_variables.rs
+++ b/kcl-ezpz/src/textual/geometry_variables.rs
@@ -7,8 +7,8 @@ const VARS_PER_CIRCLE: usize = 3;
 pub const VARS_PER_ARC: usize = 6;
 
 /// Stores variables for different constrainable geometry.
-#[derive(Default, Clone, Debug)]
-pub struct GeometryVariables<S: State> {
+#[derive(Clone, Debug)]
+pub struct GeometryVariables<S> {
     /// List of variables, each with an ID and a value.
     // Layout of this vec:
     // - All variables for points are stored first,
@@ -24,17 +24,31 @@ pub struct GeometryVariables<S: State> {
     state: PhantomData<S>,
 }
 
+// Must implement manually instead of deriving,
+// because S does not implement Default.
+impl<S> Default for GeometryVariables<S> {
+    fn default() -> Self {
+        Self {
+            variables: Default::default(),
+            num_points: Default::default(),
+            num_circles: Default::default(),
+            num_arcs: Default::default(),
+            state: Default::default(),
+        }
+    }
+}
+
 pub trait State {}
 
-#[derive(Default)]
 pub struct PointsState;
 impl State for PointsState {}
-#[derive(Default)]
+
 pub struct CirclesState;
 impl State for CirclesState {}
-#[derive(Default)]
+
 pub struct ArcsState;
 impl State for ArcsState {}
+
 #[derive(Clone)]
 pub struct DoneState;
 impl State for DoneState {}
@@ -55,14 +69,14 @@ impl<S: State> GeometryVariables<S> {
     }
 
     /// Look up the variables for a given 2D point.
-    pub fn get_point_ids(&self, point_id: usize) -> PointVars {
+    pub fn point_ids(&self, point_id: usize) -> PointVars {
         let x = self.variables[VARS_PER_POINT * point_id].0;
         let y = self.variables[VARS_PER_POINT * point_id + 1].0;
         PointVars { x, y }
     }
 
     /// Look up the variables for a given circle.
-    pub fn get_circle_ids(&self, circle_id: usize) -> CircleVars {
+    pub fn circle_ids(&self, circle_id: usize) -> CircleVars {
         let start_of_circles = VARS_PER_POINT * self.num_points;
         let x = self.variables[start_of_circles + VARS_PER_CIRCLE * circle_id].0;
         let y = self.variables[start_of_circles + VARS_PER_CIRCLE * circle_id + 1].0;
@@ -74,7 +88,7 @@ impl<S: State> GeometryVariables<S> {
     }
 
     /// Look up the variables for a given arc.
-    pub fn get_arc_ids(&self, arc_id: usize) -> ArcVars {
+    pub fn arc_ids(&self, arc_id: usize) -> ArcVars {
         let start_of_arcs = VARS_PER_POINT * self.num_points;
         let ax = self.variables[start_of_arcs + VARS_PER_ARC * arc_id].0;
         let ay = self.variables[start_of_arcs + VARS_PER_ARC * arc_id + 1].0;


### PR DESCRIPTION
Makes the code more idiomatic. Generally in Rust, [getter methods don't have a `get_` prefix](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter).