### PR TITLE
Rename lints to warnings

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 
 use clap::Parser;
 use kcl_ezpz::{
-    FailureOutcome, Lint,
+    FailureOutcome, Warning,
     textual::{Arc, Circle, Outcome, Point, Problem},
 };
 
@@ -338,14 +338,14 @@ fn main_inner(cli: &Cli) -> Result<RunResult, String> {
 fn print_output((outcome, duration): &(Outcome, Duration), show_points: bool) {
     let Outcome {
         iterations,
-        lints,
+        warnings,
         points,
         circles,
         arcs,
         num_vars,
         num_eqs,
     } = outcome;
-    print_lints(lints);
+    print_warnings(warnings);
     print_problem_size(*num_vars, *num_eqs);
     println!("Iterations needed: {iterations}");
     print_performance(*duration);
@@ -386,11 +386,11 @@ fn print_performance(duration: Duration) {
     println!("i.e. {solves_per_second} solves per second");
 }
 
-fn print_lints(lints: &[Lint]) {
+fn print_warnings(warnings: &[Warning]) {
     use colored::Colorize;
-    if !lints.is_empty() {
-        println!("Lints:");
-        for lint in lints {
+    if !warnings.is_empty() {
+        println!("Warnings:");
+        for lint in warnings {
             println!("\t{}", lint.content.yellow());
         }
     }
@@ -411,11 +411,11 @@ fn print_failure_output(outcome: FailureOutcome) {
     use colored::Colorize;
     let FailureOutcome {
         error,
-        lints,
+        warnings,
         num_vars,
         num_eqs,
     } = outcome;
-    print_lints(&lints);
+    print_warnings(&warnings);
     print_problem_size(num_vars, num_eqs);
     eprintln!("{}: {}", "Could not solve system".red(), error);
     if num_eqs > num_vars {

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -231,7 +231,7 @@ fn arc_equidistant() {
 }
 
 #[test]
-fn lints() {
+fn warnings() {
     let txt = "# constraints
 point p
 point q
@@ -254,10 +254,10 @@ s roughly (5, 6)
 ";
     let problem = Problem::from_str(txt).unwrap();
     let solved = problem.to_constraint_system().unwrap().solve().unwrap();
-    assert!(!solved.lints.is_empty());
+    assert!(!solved.warnings.is_empty());
     assert_eq!(
-        solved.lints,
-        vec![Lint {
+        solved.warnings,
+        vec![Warning {
             about_constraint: Some(7),
             content: content_for_angle(true, 0.0),
         }]

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -7,8 +7,8 @@ use crate::Constraint;
 use crate::Error;
 use crate::FailureOutcome;
 use crate::IdGenerator;
-use crate::Lint;
 use crate::SolveOutcome;
+use crate::Warning;
 use crate::constraints::AngleKind;
 use crate::datatypes;
 use crate::datatypes::CircularArc;
@@ -396,7 +396,7 @@ impl ConstraintSystem<'_> {
         // Pass into the solver.
         let SolveOutcome {
             iterations,
-            lints,
+            warnings,
             final_values,
         } = self.solve_no_metadata(config)?;
         let num_points = self.inner_points.len();
@@ -447,7 +447,7 @@ impl ConstraintSystem<'_> {
         }
         Ok(Outcome {
             iterations,
-            lints,
+            warnings,
             points: final_points,
             circles: final_circles,
             arcs: final_arcs,
@@ -460,7 +460,7 @@ impl ConstraintSystem<'_> {
 #[derive(Debug)]
 pub struct Outcome {
     pub iterations: usize,
-    pub lints: Vec<Lint>,
+    pub warnings: Vec<Warning>,
     pub points: IndexMap<String, Point>,
     pub circles: IndexMap<String, Circle>,
     pub arcs: IndexMap<String, Arc>,


### PR DESCRIPTION
We will add runtime warnings here, like degenerate cases or over/underconstrained problems.