### PR TITLE
CLI: Define and draw straight lines

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -108,6 +108,7 @@ fn print_output((outcome, duration): &(Outcome, Duration), show_points: bool) {
         arcs,
         num_vars,
         num_eqs,
+        lines: _, // these are only used for visuals
     } = outcome;
     print_warnings(warnings);
     print_problem_size(*num_vars, *num_eqs);

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -29,6 +29,7 @@ pub struct Problem {
     pub inner_points: Vec<Label>,
     pub inner_circles: Vec<Label>,
     pub inner_arcs: Vec<Label>,
+    pub inner_lines: Vec<(Label, Label)>,
     pub point_guesses: Vec<PointGuess>,
     pub scalar_guesses: Vec<ScalarGuess>,
 }
@@ -85,6 +86,12 @@ pub struct Label(String);
 impl From<&str> for Label {
     fn from(value: &str) -> Self {
         Self(value.to_owned())
+    }
+}
+
+impl From<Label> for String {
+    fn from(value: Label) -> Self {
+        value.0
     }
 }
 

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -181,6 +181,7 @@ impl Problem {
                 Instruction::DeclarePoint(_) => {}
                 Instruction::DeclareCircle(_) => {}
                 Instruction::DeclareArc(_) => {}
+                Instruction::Line(_) => {}
                 Instruction::CircleRadius(CircleRadius { circle, radius }) => {
                     let circ = &circle.0;
                     let center_id = datum_point_for_label(&Label(format!("{circ}.center")))?;
@@ -368,6 +369,7 @@ impl Problem {
             inner_points: &self.inner_points,
             inner_circles: &self.inner_circles,
             inner_arcs: &self.inner_arcs,
+            inner_lines: &self.inner_lines,
         })
     }
 }
@@ -379,6 +381,7 @@ pub struct ConstraintSystem<'a> {
     inner_points: &'a [Label],
     inner_circles: &'a [Label],
     inner_arcs: &'a [Label],
+    inner_lines: &'a [(Label, Label)],
 }
 
 impl ConstraintSystem<'_> {
@@ -452,6 +455,7 @@ impl ConstraintSystem<'_> {
             circles: final_circles,
             arcs: final_arcs,
             num_vars,
+            lines: self.inner_lines.to_vec(),
             num_eqs,
         })
     }
@@ -464,6 +468,7 @@ pub struct Outcome {
     pub points: IndexMap<String, Point>,
     pub circles: IndexMap<String, Circle>,
     pub arcs: IndexMap<String, Arc>,
+    pub lines: Vec<(Label, Label)>,
     pub num_vars: usize,
     pub num_eqs: usize,
 }

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -21,6 +21,7 @@ pub enum Instruction {
     FixCenterPointComponent(FixCenterPointComponent),
     LinesEqualLength(LinesEqualLength),
     IsArc(IsArc),
+    Line(Line),
 }
 
 #[derive(Debug)]
@@ -63,6 +64,12 @@ pub struct LinesEqualLength {
 #[derive(Debug)]
 pub struct IsArc {
     pub arc_label: Label,
+}
+
+#[derive(Debug)]
+pub struct Line {
+    pub p0: Label,
+    pub p1: Label,
 }
 
 #[derive(Debug)]

--- a/test_cases/two_rectangles/problem.txt
+++ b/test_cases/two_rectangles/problem.txt
@@ -3,6 +3,10 @@ point p0
 point p1
 point p2
 point p3
+line(p0, p1)
+line(p1, p2)
+line(p2, p3)
+line(p3, p0)
 p0 = (1,1)
 horizontal(p0, p1)
 horizontal(p2, p3)


### PR DESCRIPTION
For visualization purposes only, they have no effect on the solver.

For example:

<img width="1600" height="1600" alt="foo" src="https://github.com/user-attachments/assets/79089f67-5dfa-4114-9675-b48021b61acc" />
