### PR TITLE
Wrap constraints with ID into ConstraintEntry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+mutants.out/
 node_modules
 package.json
 package-lock.json

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -12,6 +12,20 @@ fn wrap_angle_delta(delta: f64) -> f64 {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ConstraintEntry<'c> {
+    /// The constraint itself.
+    pub constraint: &'c Constraint,
+    /// The constraint's ID.
+    pub id: usize,
+}
+
+impl<'c> AsRef<Constraint> for ConstraintEntry<'c> {
+    fn as_ref(&self) -> &Constraint {
+        self.constraint
+    }
+}
+
 /// Each geometric constraint we support.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]

--- a/kcl-ezpz/src/warnings.rs
+++ b/kcl-ezpz/src/warnings.rs
@@ -1,5 +1,6 @@
 use crate::{
     Constraint,
+    constraints::ConstraintEntry,
     datatypes::{Angle, AngleKind},
 };
 
@@ -19,17 +20,17 @@ pub enum WarningContent {
     ShouldBePerpendicular(Angle),
 }
 
-pub fn lint(constraints: &[Constraint]) -> Vec<Warning> {
+pub fn lint(constraints: &[ConstraintEntry]) -> Vec<Warning> {
     let mut warnings = Vec::default();
-    for (i, constraint) in constraints.iter().enumerate() {
-        match constraint {
+    for constraint in constraints.iter() {
+        match constraint.constraint {
             Constraint::LinesAtAngle(_, _, AngleKind::Other(theta))
                 if nearly_eq(theta.to_degrees(), 0.0)
                     || nearly_eq(theta.to_degrees(), 360.0)
                     || nearly_eq(theta.to_degrees(), 180.0) =>
             {
                 warnings.push(Warning {
-                    about_constraint: Some(i),
+                    about_constraint: Some(constraint.id),
                     content: WarningContent::ShouldBeParallel(*theta),
                 });
             }
@@ -37,7 +38,7 @@ pub fn lint(constraints: &[Constraint]) -> Vec<Warning> {
                 if nearly_eq(theta.to_degrees(), 90.0) || nearly_eq(theta.to_degrees(), -90.0) =>
             {
                 warnings.push(Warning {
-                    about_constraint: Some(i),
+                    about_constraint: Some(constraint.id),
                     content: WarningContent::ShouldBePerpendicular(*theta),
                 });
             }


### PR DESCRIPTION
Instead of relying on the order constraints come in, give each constraint an ID, and track it throughout execution.

This is going to be helpful for https://github.com/KittyCAD/ezpz/pull/147, where the order of each constraint in the constraint vec given by the user may be reordered, because the order they're in might not correspond to their prioritized order.

This should not have any effect on the public API.