### PR TITLE
Textual: Allow constraining arc a/b points

### DIFF
--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -308,6 +308,32 @@ impl Problem {
                         });
                     }
                 }
+                Instruction::FixObjectPointComponent(FixObjectPointComponent {
+                    object,
+                    value,
+                    point,
+                    point_component,
+                }) => {
+                    // Is this center talking about an arc object?
+                    if let Some(arc_id) = self.inner_arcs.iter().position(|label| label == object) {
+                        let the_point = if point.0 == "a" {
+                            initial_guesses.arc_ids(arc_id).a
+                        } else if point.0 == "b" {
+                            initial_guesses.arc_ids(arc_id).b
+                        } else {
+                            panic!("Unrecognized label {}", point.0)
+                        };
+                        let id = match point_component {
+                            Component::X => the_point.x,
+                            Component::Y => the_point.y,
+                        };
+                        constraints.push(Constraint::Fixed(id, *value));
+                    } else {
+                        return Err(Error::UndefinedPoint {
+                            label: object.0.clone(),
+                        });
+                    }
+                }
                 Instruction::Vertical(Vertical { label }) => {
                     let p0 = datum_point_for_label(&label.0)?;
                     let p1 = datum_point_for_label(&label.1)?;

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -21,6 +21,7 @@ pub enum Instruction {
     Tangent(Tangent),
     ArcRadius(ArcRadius),
     FixCenterPointComponent(FixCenterPointComponent),
+    FixObjectPointComponent(FixObjectPointComponent),
     LinesEqualLength(LinesEqualLength),
     IsArc(IsArc),
     PointLineDistance(PointLineDistance),
@@ -153,5 +154,13 @@ pub struct FixPointComponent {
 pub struct FixCenterPointComponent {
     pub object: Label,
     pub center_component: Component,
+    pub value: f64,
+}
+
+#[derive(Debug)]
+pub struct FixObjectPointComponent {
+    pub object: Label,
+    pub point: Label,
+    pub point_component: Component,
     pub value: f64,
 }

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -4,8 +4,9 @@ use crate::{
         ScalarGuess,
         instruction::{
             AngleLine, ArcRadius, CircleRadius, DeclareArc, DeclareCircle, Distance,
-            FixCenterPointComponent, IsArc, Line, LinesEqualLength, Midpoint, Parallel,
-            Perpendicular, PointLineDistance, PointsCoincident, Symmetric, Tangent,
+            FixCenterPointComponent, FixObjectPointComponent, IsArc, Line, LinesEqualLength,
+            Midpoint, Parallel, Perpendicular, PointLineDistance, PointsCoincident, Symmetric,
+            Tangent,
         },
     },
 };
@@ -381,6 +382,9 @@ fn parse_instruction(i: &mut &str) -> WResult<Vec<Instruction>> {
         parse_fix_center_point_component
             .map(Instruction::FixCenterPointComponent)
             .map(sv),
+        parse_fix_some_point_component
+            .map(Instruction::FixObjectPointComponent)
+            .map(sv),
         assign_point,
         parse_horizontal.map(Instruction::Horizontal).map(sv),
         parse_coincident.map(Instruction::PointsCoincident).map(sv),
@@ -500,6 +504,29 @@ fn parse_fix_center_point_component(i: &mut &str) -> WResult<FixCenterPointCompo
                 object: label,
                 center_component: component,
                 value,
+            },
+        )
+        .parse_next(i)
+}
+
+fn parse_fix_some_point_component(i: &mut &str) -> WResult<FixObjectPointComponent> {
+    (
+        parse_label,
+        '.',
+        parse_label,
+        '.',
+        parse_component,
+        delimited(space0, '=', space0),
+        parse_number,
+    )
+        .map(
+            |(label, _dot, point_label, _dot2, component, _equals, value)| {
+                FixObjectPointComponent {
+                    object: label,
+                    value,
+                    point: point_label,
+                    point_component: component,
+                }
             },
         )
         .parse_next(i)

--- a/test_cases/arc_radius/problem.md
+++ b/test_cases/arc_radius/problem.md
@@ -3,6 +3,7 @@ point p
 arc a
 a.center.x = 0
 a.center.y = 0
+a.a.x = 0
 arc_radius(a, 5)
 
 # guesses


### PR DESCRIPTION
Previously you could only fix an arc's center.
Now you can fix an arc's A or B point (either end).