### PR TITLE
Release ezpz 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-ezpz"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-ezpz"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
Added: optional freedom analysis
Removed: `fn solve` (use `fn solve_with_priority` now)