### PR TITLE
Release 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-ezpz"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-ezpz"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
Added:

 - Freedom analysis reports underconstrained variables (#170)

Internal changes:
 - Replace f64 math with libm math, for consistency (#171)
 - Bump criterion (#167)