### PR TITLE
Release version 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-ezpz"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-ezpz"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
- Enable more lints
- Document more items
- Remove `kcl_ezpz::Error`, it's now two separate error types `NonLinearSystemError` and `TextualError`. KCL should only ever see the former in relevant functions, not the latter.
- Remove useless `is_underconstrained` field in FreedomAnalysis
- Remove useless JS dep