### PR TITLE
New 'ScalarEqual' constraint

### DIFF
--- a/kcl-ezpz/proptest-regressions/tests/proptests.txt
+++ b/kcl-ezpz/proptest-regressions/tests/proptests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 0348ec3503f22b38491b7d33573d30e4b2e958b48a9dbbc79a2e900f62a2a470 # shrinks to x = 0.0, y = 0.0, guess_x = 0.0, guess_y = 0.846792320291437

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -226,6 +226,7 @@ impl Constraint {
                 *residual0 = actual - expected;
             }
             Constraint::ScalarEqual(x, y) => {
+                // Residual equation R: x-y=0
                 let vx = current_assignments[layout.index_of(*x)];
                 let vy = current_assignments[layout.index_of(*y)];
                 *residual0 = vx - vy;
@@ -618,18 +619,16 @@ impl Constraint {
                 );
             }
             Constraint::ScalarEqual(x, y) => {
-                // Residual equation: x-y=0
+                // Residual equation R: x-y=0
                 // dR/dx: 1
                 // dR/dy: -1
-                let vx = current_assignments[layout.index_of(*x)];
-                let vy = current_assignments[layout.index_of(*y)];
                 row0.push(JacobianVar {
                     id: *x,
-                    partial_derivative: vx,
+                    partial_derivative: 1.0,
                 });
                 row0.push(JacobianVar {
                     id: *y,
-                    partial_derivative: -vy,
+                    partial_derivative: -1.0,
                 });
             }
             Constraint::LinesAtAngle(line0, line1, expected_angle) => {


### PR DESCRIPTION
Used for "these circles have equal radii", or possibly as a replacement for "these two points are horizontal (same y) or vertical (same x)".

Rather than build a handcrafted test case with the text representation, I used a property test, to try a lot of different possible formulations. This works well here where the constraint is very simple to check.