### PR TITLE
Release 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-ezpz"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-ezpz"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
## Added

 - New constraints for
   - vertical distance (#188)
   - horizontal distance (#188)
   - vertical point-line distance (#189)
   - horizontal point-line distance (#190)
   - equality of two variables (#187)

## Fixed

 - Properly report the lowest priority solved (#184)

## Changed

 - Arcs no longer have two points `a` and `b`. They now have a `start` and `end`. The arc is defined as counterclockwise from `start` to `end`. Thanks Kurt (#191)