### PR TITLE
Release 0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-ezpz"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-ezpz"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
Changed:

 - Most structs now have #[non_exhaustive]. You can opt into exhaustive matches via the `unstable-exhaustive` feature.
 - Removed `pub` from many fields, replacing with getter methods or builder APIs.