### PR TITLE
New simple interface for getting solved geometry

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -9,7 +9,8 @@ use std::{
 use clap::Parser;
 use kcl_ezpz::{
     Constraint, FailureOutcome, Warning,
-    textual::{Outcome, Point, Problem},
+    datatypes::outputs::{self, Point},
+    textual::{Outcome, Problem},
 };
 
 mod visualize;
@@ -123,19 +124,19 @@ fn print_output((outcome, duration, constraints): &RunOutcome, show_points: bool
     print_performance(*duration);
     if show_points {
         println!("Points:");
-        for (label, Point { x, y }) in points {
+        for (label, outputs::Point { x, y }) in points {
             println!("\t{label}: ({x:.2}, {y:.2})",);
         }
         if !circles.is_empty() {
             println!("Circles:");
-            for (label, kcl_ezpz::textual::Circle { radius, center }) in circles {
+            for (label, outputs::Circle { radius, center }) in circles {
                 let Point { x, y } = center;
                 println!("\t{label}: center = ({x:.2}, {y:.2}), radius = {radius:.2}",);
             }
         }
         if !arcs.is_empty() {
             println!("Arcs:");
-            for (label, kcl_ezpz::textual::Arc { a, b, center }) in arcs {
+            for (label, outputs::Arc { a, b, center }) in arcs {
                 let Point { x, y } = center;
                 let ax = a.x;
                 let ay = a.y;

--- a/ezpz-cli/src/visualize.rs
+++ b/ezpz-cli/src/visualize.rs
@@ -1,6 +1,7 @@
 use std::f64::consts::PI;
 
-use kcl_ezpz::textual::{Arc, Circle, Outcome, Point};
+use kcl_ezpz::datatypes::outputs::{Arc, Circle, Point};
+use kcl_ezpz::textual::Outcome;
 use plotters::{coord::types::RangedCoordf64, prelude::*};
 
 const POINT_COLOR: RGBColor = RGBColor(0x58, 0x50, 0x8d);

--- a/kcl-ezpz/src/analysis.rs
+++ b/kcl-ezpz/src/analysis.rs
@@ -59,7 +59,7 @@ impl FreedomAnalysis {
         &self.underconstrained
     }
 
-    /// Just like [`underconstrained`] except it consumes the struct to take ownership.
+    /// Just like [`FreedomAnalysis::underconstrained`] except it consumes the struct to take ownership.
     pub fn into_underconstrained(self) -> Vec<crate::Id> {
         self.underconstrained
     }

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -26,7 +26,7 @@ pub enum Constraint {
     /// (i.e. touches its perimeter in exactly one place)
     /// Note this constraint is directional: making circle C
     /// tangent to PQ will produce a different solution to QP.
-    LineTangentToCircle(LineSegment, Circle),
+    LineTangentToCircle(LineSegment, DatumCircle),
     /// These two points should be a given distance apart.
     Distance(DatumPoint, DatumPoint, f64),
     /// These two points should be a given vertical distance apart.
@@ -47,7 +47,7 @@ pub enum Constraint {
     /// These two points must coincide.
     PointsCoincident(DatumPoint, DatumPoint),
     /// Constraint radius of a circle
-    CircleRadius(Circle, f64),
+    CircleRadius(DatumCircle, f64),
     /// These lines should be the same distance.
     LinesEqualLength(LineSegment, LineSegment),
     /// The arc should have the given radius.

--- a/kcl-ezpz/src/datatypes.rs
+++ b/kcl-ezpz/src/datatypes.rs
@@ -1,5 +1,7 @@
 use crate::{IdGenerator, id::Id};
 
+pub mod outputs;
+
 pub(crate) trait Datum {
     fn all_variables(&self) -> impl IntoIterator<Item = Id>;
 }
@@ -167,14 +169,14 @@ impl Datum for LineSegment {
 /// A circle.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
-pub struct Circle {
+pub struct DatumCircle {
     /// Center of the circle.
     pub center: DatumPoint,
     /// Radius distance of the circle.
     pub radius: DatumDistance,
 }
 
-impl Datum for Circle {
+impl Datum for DatumCircle {
     /// Get all IDs of all variables, i.e. center components and radius.
     fn all_variables(&self) -> impl IntoIterator<Item = Id> {
         [self.center.id_x(), self.center.id_y(), self.radius.id]
@@ -237,7 +239,7 @@ mod tests {
             vec![0, 1, 2, 3]
         );
 
-        let circle = Circle {
+        let circle = DatumCircle {
             center: p0,
             radius: DatumDistance::new(ids.next_id()),
         };

--- a/kcl-ezpz/src/datatypes/outputs.rs
+++ b/kcl-ezpz/src/datatypes/outputs.rs
@@ -1,0 +1,69 @@
+//! The final solved values of various geometry.
+
+/// A 2D point that ezpz solved for, i.e. found values for all its variables.
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct Point {
+    #[allow(missing_docs)]
+    pub x: f64,
+    #[allow(missing_docs)]
+    pub y: f64,
+}
+
+/// Points can be easily converted to/from an (x, y) pair.
+impl From<(f64, f64)> for Point {
+    fn from((x, y): (f64, f64)) -> Self {
+        Self { x, y }
+    }
+}
+
+/// Points can be easily converted to/from an (x, y) pair.
+impl From<Point> for (f64, f64) {
+    fn from(Point { x, y }: Point) -> Self {
+        (x, y)
+    }
+}
+
+/// A 2D circle that ezpz solved for, i.e. found values for all its variables.
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct Circle {
+    /// Radius of the circle.
+    pub radius: f64,
+    /// Center of the circle.
+    pub center: Point,
+}
+
+/// A 2D circular arc that ezpz solved for, i.e. found values for all its variables.
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct Arc {
+    /// A point at one end of the arc.
+    /// This doesn't specifically mean the start or end or anything.
+    pub a: Point,
+    /// A point at one end of the arc.
+    /// This doesn't specifically mean the start or end or anything.
+    pub b: Point,
+    /// Center of the arc.
+    pub center: Point,
+}
+
+impl std::fmt::Display for Point {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({},{})", self.x, self.y)
+    }
+}
+
+impl Point {
+    /// Euclidean distance between two points.
+    pub fn euclidean_distance(&self, r: Point) -> f64 {
+        use crate::vector::V;
+        V::new(self.x, self.y).euclidean_distance(V::new(r.x, r.y))
+    }
+}
+
+/// Component of a 2D point.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum Component {
+    /// Horizontal (X) component.
+    X,
+    /// Vertical (Y) component.
+    Y,
+}

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -2,8 +2,8 @@ use std::{f64::consts::PI, str::FromStr};
 
 use super::*;
 use crate::{
-    datatypes::{Angle, CircularArc, DatumPoint},
-    textual::{OutcomeAnalysis, Point, Problem},
+    datatypes::{Angle, CircularArc, DatumPoint, outputs::Point},
+    textual::{OutcomeAnalysis, Problem},
 };
 
 mod proptests;

--- a/kcl-ezpz/src/tests/proptests.rs
+++ b/kcl-ezpz/src/tests/proptests.rs
@@ -4,10 +4,10 @@ use proptest::prelude::*;
 
 use crate::{
     Config, Constraint, ConstraintRequest, EPSILON, Id, IdGenerator,
+    datatypes::outputs::Point,
     datatypes::{CircularArc, DatumPoint, LineSegment},
     solve,
     tests::assert_nearly_eq,
-    textual::Point,
 };
 
 fn run(txt: &str) -> crate::textual::Outcome {

--- a/kcl-ezpz/src/textual.rs
+++ b/kcl-ezpz/src/textual.rs
@@ -11,6 +11,7 @@ pub use executor::OutcomeAnalysis;
 use instruction::Instruction;
 use winnow::Parser;
 
+use crate::datatypes::outputs::Point;
 use crate::textual::parser::parse_problem;
 
 #[allow(missing_docs)]
@@ -45,60 +46,6 @@ impl FromStr for Problem {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse_problem.parse(s).map_err(|e| e.to_string())
     }
-}
-
-/// A 2D point that ezpz solved for, i.e. found values for all its variables.
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-pub struct Point {
-    #[allow(missing_docs)]
-    pub x: f64,
-    #[allow(missing_docs)]
-    pub y: f64,
-}
-
-/// A 2D circle that ezpz solved for, i.e. found values for all its variables.
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-pub struct Circle {
-    /// Radius of the circle.
-    pub radius: f64,
-    /// Center of the circle.
-    pub center: Point,
-}
-
-/// A 2D circular arc that ezpz solved for, i.e. found values for all its variables.
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-pub struct Arc {
-    /// A point at one end of the arc.
-    /// This doesn't specifically mean the start or end or anything.
-    pub a: Point,
-    /// A point at one end of the arc.
-    /// This doesn't specifically mean the start or end or anything.
-    pub b: Point,
-    /// Center of the arc.
-    pub center: Point,
-}
-
-impl std::fmt::Display for Point {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({},{})", self.x, self.y)
-    }
-}
-
-impl Point {
-    /// Euclidean distance between two points.
-    pub fn euclidean_distance(&self, r: Point) -> f64 {
-        use crate::vector::V;
-        V::new(self.x, self.y).euclidean_distance(V::new(r.x, r.y))
-    }
-}
-
-/// Component of a 2D point.
-#[derive(Debug)]
-pub enum Component {
-    #[allow(missing_docs)]
-    X,
-    #[allow(missing_docs)]
-    Y,
 }
 
 /// The label of a variable being solved for in the system.

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -19,14 +19,15 @@ use crate::datatypes::CircularArc;
 use crate::datatypes::DatumDistance;
 use crate::datatypes::DatumPoint;
 use crate::datatypes::LineSegment;
+use crate::datatypes::outputs::Arc;
+use crate::datatypes::outputs::{Circle, Component, Point};
 use crate::error::TextualError;
-use crate::textual::Arc;
+use crate::textual::Label;
 use crate::textual::geometry_variables::DoneState;
 use crate::textual::geometry_variables::GeometryVariables;
 use crate::textual::geometry_variables::PointsState;
 use crate::textual::geometry_variables::VARS_PER_ARC;
 use crate::textual::instruction::*;
-use crate::textual::{Circle, Component, Label, Point};
 
 use super::Instruction;
 use super::Problem;
@@ -195,7 +196,7 @@ impl Problem {
                     let center_id = datum_point_for_label(&Label(format!("{circ}.center")))?;
                     let radius_id = datum_distance_for_label(&Label(format!("{circ}.radius")))?;
                     constraints.push(Constraint::CircleRadius(
-                        datatypes::Circle {
+                        datatypes::DatumCircle {
                             center: center_id,
                             radius: radius_id,
                         },
@@ -247,7 +248,7 @@ impl Problem {
                     };
                     constraints.push(Constraint::LineTangentToCircle(
                         line,
-                        datatypes::Circle {
+                        datatypes::DatumCircle {
                             center: center_id,
                             radius: radius_id,
                         },

--- a/kcl-ezpz/src/textual/geometry_variables.rs
+++ b/kcl-ezpz/src/textual/geometry_variables.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{Id, IdGenerator, datatypes::DatumPoint, textual::Point};
+use crate::{Id, IdGenerator, datatypes::DatumPoint, datatypes::outputs::Point};
 
 const VARS_PER_POINT: usize = 2;
 const VARS_PER_CIRCLE: usize = 3;

--- a/kcl-ezpz/src/textual/instruction.rs
+++ b/kcl-ezpz/src/textual/instruction.rs
@@ -1,6 +1,6 @@
-use crate::datatypes::Angle;
+use crate::datatypes::{Angle, outputs::Component};
 
-use super::{Component, Label};
+use super::Label;
 
 #[derive(Debug)]
 pub(crate) enum Instruction {

--- a/kcl-ezpz/src/textual/parser.rs
+++ b/kcl-ezpz/src/textual/parser.rs
@@ -1,5 +1,6 @@
 use crate::{
     datatypes::Angle,
+    datatypes::outputs::{Component, Point},
     textual::{
         ScalarGuess,
         instruction::{
@@ -12,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    Component, Label, Point, PointGuess, Problem,
+    Label, PointGuess, Problem,
     instruction::{DeclarePoint, FixPointComponent, Horizontal, Instruction, Vertical},
 };
 use winnow::{


### PR DESCRIPTION
Adds some new helper methods to `SolveOutcome` for finding the solved geometry.

Before:

```rust
let (px, py) = (
  solution.final_values()[q.id_x() as usize],
  solution.final_values()[q.id_y() as usize],
);
let (qx, qy) = (
  solution.final_values()[q.id_x() as usize],
  solution.final_values()[q.id_y() as usize],
);
println!("P = ({}, {})", px, py);
println!("Q = ({}, {})", qx, qy);
```

After:

```rust
let solved_p = solution.final_value_point(&p);
let solved_q = solution.final_value_point(&q);
println!("P = ({}, {})", solved_p.x, solved_p.y);
println!("Q = ({}, {})", solved_q.x, solved_q.y);
```