### PR TITLE
Refactor datatypes module for consistency

### DIFF
--- a/ezpz-wasm/src/lib.rs
+++ b/ezpz-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use kcl_ezpz::{
     Config, Constraint, ConstraintRequest, IdGenerator,
-    datatypes::{DatumPoint, DatumLineSegment},
+    datatypes::inputs::{DatumLineSegment, DatumPoint},
     solve,
 };
 use wasm_bindgen::prelude::*;

--- a/kcl-ezpz/benches/solver_bench.rs
+++ b/kcl-ezpz/benches/solver_bench.rs
@@ -4,7 +4,7 @@ use std::{hint::black_box, str::FromStr};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use kcl_ezpz::{
     Config, Constraint, ConstraintRequest, IdGenerator,
-    datatypes::{DatumPoint, DatumLineSegment},
+    datatypes::inputs::{DatumLineSegment, DatumPoint},
     solve,
     textual::Problem,
 };

--- a/kcl-ezpz/src/constraints.rs
+++ b/kcl-ezpz/src/constraints.rs
@@ -1,4 +1,4 @@
-use crate::{EPSILON, datatypes::*, id::Id, solver::Layout, vector::V};
+use crate::{EPSILON, datatypes::inputs::*, datatypes::*, id::Id, solver::Layout, vector::V};
 use std::f64::consts::PI;
 
 #[derive(Clone, Copy, Debug)]

--- a/kcl-ezpz/src/datatypes.rs
+++ b/kcl-ezpz/src/datatypes.rs
@@ -1,10 +1,5 @@
-use crate::{IdGenerator, id::Id};
-
+pub mod inputs;
 pub mod outputs;
-
-pub(crate) trait Datum {
-    fn all_variables(&self) -> impl IntoIterator<Item = Id>;
-}
 
 /// Possible angles, with specific descriptors for special angles
 /// like parallel or perpendicular.
@@ -74,147 +69,12 @@ impl Angle {
     }
 }
 
-/// A distance that can be found by the constraint solver.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
-pub struct DatumDistance {
-    /// ID of the variable for this distance.
-    pub id: Id,
-}
-
-impl DatumDistance {
-    /// Create a new `DatumDistance`.
-    pub fn new(id: Id) -> Self {
-        Self { id }
-    }
-}
-
-impl Datum for DatumDistance {
-    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
-        [self.id]
-    }
-}
-
-/// 2D point.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
-pub struct DatumPoint {
-    /// ID of the variable for this point's X component.
-    pub x_id: Id,
-    /// ID of the variable for this point's Y component.
-    pub y_id: Id,
-}
-
-impl DatumPoint {
-    /// Create a new `DatumPoint` from an ID generator.
-    pub fn new(id_generator: &mut IdGenerator) -> Self {
-        Self {
-            x_id: id_generator.next_id(),
-            y_id: id_generator.next_id(),
-        }
-    }
-
-    /// Create a new `DatumPoint` with these specific IDs.
-    pub fn new_xy(x: Id, y: Id) -> Self {
-        Self { x_id: x, y_id: y }
-    }
-
-    /// Id for the X component of the point.
-    #[inline(always)]
-    pub fn id_x(&self) -> Id {
-        self.x_id
-    }
-
-    /// Id for the Y component of the point.
-    #[inline(always)]
-    pub fn id_y(&self) -> Id {
-        self.y_id
-    }
-}
-
-impl Datum for DatumPoint {
-    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
-        [self.id_x(), self.id_y()]
-    }
-}
-
-/// Finite segment of a line.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
-pub struct DatumLineSegment {
-    /// Point for one end of this line.
-    pub p0: DatumPoint,
-    /// Point for the other end of this line.
-    pub p1: DatumPoint,
-}
-
-impl DatumLineSegment {
-    /// Create a new `LineSegment`.
-    pub fn new(p0: DatumPoint, p1: DatumPoint) -> Self {
-        Self { p0, p1 }
-    }
-}
-
-impl Datum for DatumLineSegment {
-    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
-        [
-            self.p0.id_x(),
-            self.p0.id_y(),
-            self.p1.id_x(),
-            self.p1.id_y(),
-        ]
-    }
-}
-
-/// A circle.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
-pub struct DatumCircle {
-    /// Center of the circle.
-    pub center: DatumPoint,
-    /// Radius distance of the circle.
-    pub radius: DatumDistance,
-}
-
-impl Datum for DatumCircle {
-    /// Get all IDs of all variables, i.e. center components and radius.
-    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
-        [self.center.id_x(), self.center.id_y(), self.radius.id]
-    }
-}
-
-/// Arc on the perimeter of a circle.
-/// The arc always goes counter-clockwise from start to end.
-/// To get a clockwise arc, swap start and end.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
-pub struct DatumCircularArc {
-    /// Center of the circle
-    pub center: DatumPoint,
-    /// Start point of the arc.
-    /// Distance(start, center) == Distance(end, center)
-    pub start: DatumPoint,
-    /// End point of the arc.
-    /// Distance(start, center) == Distance(end, center)
-    pub end: DatumPoint,
-}
-
-impl Datum for DatumCircularArc {
-    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
-        [
-            self.start.id_x(),
-            self.start.id_y(),
-            self.end.id_x(),
-            self.end.id_y(),
-            self.center.id_x(),
-            self.center.id_y(),
-        ]
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use crate::IdGenerator;
+
     use super::*;
+    use inputs::*;
     use std::f64::consts::PI;
 
     #[test]

--- a/kcl-ezpz/src/datatypes/inputs.rs
+++ b/kcl-ezpz/src/datatypes/inputs.rs
@@ -1,0 +1,145 @@
+//! Geometric entities that can be constrained and solved by ezpz.
+
+use crate::{Id, IdGenerator};
+
+pub(crate) trait Datum {
+    fn all_variables(&self) -> impl IntoIterator<Item = Id>;
+}
+
+/// A distance that can be found by the constraint solver.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct DatumDistance {
+    /// ID of the variable for this distance.
+    pub id: Id,
+}
+
+impl DatumDistance {
+    /// Create a new `DatumDistance`.
+    pub fn new(id: Id) -> Self {
+        Self { id }
+    }
+}
+
+impl Datum for DatumDistance {
+    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
+        [self.id]
+    }
+}
+
+/// 2D point.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct DatumPoint {
+    /// ID of the variable for this point's X component.
+    pub x_id: Id,
+    /// ID of the variable for this point's Y component.
+    pub y_id: Id,
+}
+
+impl DatumPoint {
+    /// Create a new `DatumPoint` from an ID generator.
+    pub fn new(id_generator: &mut IdGenerator) -> Self {
+        Self {
+            x_id: id_generator.next_id(),
+            y_id: id_generator.next_id(),
+        }
+    }
+
+    /// Create a new `DatumPoint` with these specific IDs.
+    pub fn new_xy(x: Id, y: Id) -> Self {
+        Self { x_id: x, y_id: y }
+    }
+
+    /// Id for the X component of the point.
+    #[inline(always)]
+    pub fn id_x(&self) -> Id {
+        self.x_id
+    }
+
+    /// Id for the Y component of the point.
+    #[inline(always)]
+    pub fn id_y(&self) -> Id {
+        self.y_id
+    }
+}
+
+impl Datum for DatumPoint {
+    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
+        [self.id_x(), self.id_y()]
+    }
+}
+
+/// Finite segment of a line.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct DatumLineSegment {
+    /// Point for one end of this line.
+    pub p0: DatumPoint,
+    /// Point for the other end of this line.
+    pub p1: DatumPoint,
+}
+
+impl DatumLineSegment {
+    /// Create a new `LineSegment`.
+    pub fn new(p0: DatumPoint, p1: DatumPoint) -> Self {
+        Self { p0, p1 }
+    }
+}
+
+impl Datum for DatumLineSegment {
+    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
+        [
+            self.p0.id_x(),
+            self.p0.id_y(),
+            self.p1.id_x(),
+            self.p1.id_y(),
+        ]
+    }
+}
+
+/// A circle.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct DatumCircle {
+    /// Center of the circle.
+    pub center: DatumPoint,
+    /// Radius distance of the circle.
+    pub radius: DatumDistance,
+}
+
+impl Datum for DatumCircle {
+    /// Get all IDs of all variables, i.e. center components and radius.
+    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
+        [self.center.id_x(), self.center.id_y(), self.radius.id]
+    }
+}
+
+/// Arc on the perimeter of a circle.
+/// The arc always goes counter-clockwise from start to end.
+/// To get a clockwise arc, swap start and end.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct DatumCircularArc {
+    /// Center of the circle
+    pub center: DatumPoint,
+    /// Start point of the arc.
+    /// Distance(start, center) == Distance(end, center)
+    pub start: DatumPoint,
+    /// End point of the arc.
+    /// Distance(start, center) == Distance(end, center)
+    pub end: DatumPoint,
+}
+
+impl Datum for DatumCircularArc {
+    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
+        [
+            self.start.id_x(),
+            self.start.id_y(),
+            self.end.id_x(),
+            self.end.id_y(),
+            self.center.id_x(),
+            self.center.id_y(),
+        ]
+    }
+}

--- a/kcl-ezpz/src/lib.rs
+++ b/kcl-ezpz/src/lib.rs
@@ -7,7 +7,7 @@ use crate::analysis::{Analysis, NoAnalysis, SolveOutcomeAnalysis};
 pub use crate::constraint_request::ConstraintRequest;
 pub use crate::constraints::Constraint;
 use crate::constraints::ConstraintEntry;
-use crate::datatypes::{DatumCircle, DatumCircularArc, DatumDistance, DatumPoint};
+use crate::datatypes::inputs::{DatumCircle, DatumCircularArc, DatumDistance, DatumPoint};
 pub use crate::error::*;
 pub use crate::solver::Config;
 // Only public for now so that I can benchmark it.

--- a/kcl-ezpz/src/solver.rs
+++ b/kcl-ezpz/src/solver.rs
@@ -428,7 +428,7 @@ impl Model<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datatypes::DatumPoint;
+    use crate::datatypes::inputs::DatumPoint;
 
     #[test]
     fn reports_missing_guess_for_second_row_ids() {

--- a/kcl-ezpz/src/tests.rs
+++ b/kcl-ezpz/src/tests.rs
@@ -2,7 +2,11 @@ use std::{f64::consts::PI, str::FromStr};
 
 use super::*;
 use crate::{
-    datatypes::{Angle, DatumCircularArc, DatumPoint, outputs::Point},
+    datatypes::{
+        Angle,
+        inputs::{DatumCircularArc, DatumPoint},
+        outputs::Point,
+    },
     textual::{OutcomeAnalysis, Problem},
 };
 
@@ -677,7 +681,7 @@ fn arc_length_degenerate_warns() {
 
 #[test]
 fn strange_nonconvergence() {
-    use crate::datatypes::DatumPoint;
+    use crate::datatypes::inputs::DatumPoint;
     let p = DatumPoint { x_id: 0, y_id: 1 };
     let q = DatumPoint { x_id: 2, y_id: 3 };
     let r = DatumPoint { x_id: 4, y_id: 5 };
@@ -690,8 +694,8 @@ fn strange_nonconvergence() {
         ConstraintRequest::highest_priority(Constraint::PointsCoincident(r, s)),
         ConstraintRequest::highest_priority(Constraint::PointsCoincident(q, p)),
         ConstraintRequest::highest_priority(Constraint::LinesEqualLength(
-            datatypes::DatumLineSegment { p0: q, p1: r },
-            datatypes::DatumLineSegment { p0: s, p1: t },
+            datatypes::inputs::DatumLineSegment { p0: q, p1: r },
+            datatypes::inputs::DatumLineSegment { p0: s, p1: t },
         )),
     ];
     let initial_guesses = vec![

--- a/kcl-ezpz/src/tests/proptests.rs
+++ b/kcl-ezpz/src/tests/proptests.rs
@@ -4,8 +4,8 @@ use proptest::prelude::*;
 
 use crate::{
     Config, Constraint, ConstraintRequest, EPSILON, Id, IdGenerator,
+    datatypes::inputs::{DatumCircularArc, DatumLineSegment, DatumPoint},
     datatypes::outputs::Point,
-    datatypes::{DatumCircularArc, DatumPoint, DatumLineSegment},
     solve,
     tests::assert_nearly_eq,
 };

--- a/kcl-ezpz/src/textual/executor.rs
+++ b/kcl-ezpz/src/textual/executor.rs
@@ -15,10 +15,10 @@ use crate::SolveOutcomeAnalysis;
 use crate::Warning;
 use crate::datatypes;
 use crate::datatypes::AngleKind;
-use crate::datatypes::DatumCircularArc;
-use crate::datatypes::DatumDistance;
-use crate::datatypes::DatumPoint;
-use crate::datatypes::DatumLineSegment;
+use crate::datatypes::inputs::DatumCircularArc;
+use crate::datatypes::inputs::DatumDistance;
+use crate::datatypes::inputs::DatumLineSegment;
+use crate::datatypes::inputs::DatumPoint;
 use crate::datatypes::outputs::Arc;
 use crate::datatypes::outputs::{Circle, Component, Point};
 use crate::error::TextualError;
@@ -196,7 +196,7 @@ impl Problem {
                     let center_id = datum_point_for_label(&Label(format!("{circ}.center")))?;
                     let radius_id = datum_distance_for_label(&Label(format!("{circ}.radius")))?;
                     constraints.push(Constraint::CircleRadius(
-                        datatypes::DatumCircle {
+                        datatypes::inputs::DatumCircle {
                             center: center_id,
                             radius: radius_id,
                         },
@@ -248,7 +248,7 @@ impl Problem {
                     };
                     constraints.push(Constraint::LineTangentToCircle(
                         line,
-                        datatypes::DatumCircle {
+                        datatypes::inputs::DatumCircle {
                             center: center_id,
                             radius: radius_id,
                         },

--- a/kcl-ezpz/src/textual/geometry_variables.rs
+++ b/kcl-ezpz/src/textual/geometry_variables.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{Id, IdGenerator, datatypes::DatumPoint, datatypes::outputs::Point};
+use crate::{Id, IdGenerator, datatypes::inputs::DatumPoint, datatypes::outputs::Point};
 
 const VARS_PER_POINT: usize = 2;
 const VARS_PER_CIRCLE: usize = 3;

--- a/kcl-ezpz/src/warnings.rs
+++ b/kcl-ezpz/src/warnings.rs
@@ -92,7 +92,10 @@ mod tests {
     use crate::{
         Constraint,
         constraints::ConstraintEntry,
-        datatypes::{Angle, AngleKind, DatumPoint, DatumLineSegment},
+        datatypes::{
+            Angle, AngleKind,
+            inputs::{DatumLineSegment, DatumPoint},
+        },
     };
 
     fn make_lines(angle: Angle) -> Constraint {


### PR DESCRIPTION
* Use the "Datum" prefix consistently
* Move input (constrainable) types into `inputs` submodule to match the solved (constrained) types in `outputs` submodule.