### PR TITLE
Tangential arc helper function

### DIFF
--- a/kcl-ezpz/src/constraints/composite.rs
+++ b/kcl-ezpz/src/constraints/composite.rs
@@ -35,6 +35,23 @@ impl Constraint {
         ]
     }
 
+    /// Ensure the arc starts at the line's `p1`, and is tangential
+    /// (i.e. moves smoothly from the line into an arc).
+    /// Note: this does not add an arc constraint, you probably want to
+    /// use [`Self::Arc`] too.
+    pub fn tangential_arc(arc: DatumCircularArc, line: DatumLineSegment) -> [Self; 2] {
+        [
+            Self::PointsCoincident(line.p1, arc.start),
+            Self::lines_perpendicular([
+                line,
+                DatumLineSegment {
+                    p0: arc.center,
+                    p1: arc.start,
+                },
+            ]),
+        ]
+    }
+
     /// Constrains these two lines to be parallel, and to have the given perpendicular distance.
     pub fn parallel_lines_distance(lines: [DatumLineSegment; 2], distance: f64) -> [Self; 2] {
         [


### PR DESCRIPTION
Tangential arcs are a combination of:

 - Line's p1 point is coincident with the arc's start point.
 - (arc center -> arc start) is perpendicular to the line

This adds a helper function `Constraint::tangential_arc` for building this constraint, as it's a common one users will want.

## Open questions

 - This currently always uses the line's `p1` point. Should we have an option for using `p0` instead? Or will KCL handle that? Perhaps we need a general `flip(line)` which swaps the line's p0 and p1?