### PR TITLE
Release ezpz 0.2.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "ezpz"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/ezpz/Cargo.toml
+++ b/ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezpz"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
Fixes:

 - LinesAtAngle reverts to measuring the previous angle, as in 0.2.20 Regression from 0.2.21
 - Restore degeneracy check in LinesAtAngle. Regression from 0.2.21