### PR TITLE
[DRAFT] Control polygon spline

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -98,7 +98,7 @@ fn main_inner(cli: &Cli) -> Result<RunResult, String> {
     }
     let elapsed = now.elapsed();
     let duration_per_iter = elapsed / NUM_ITERS_BENCHMARK;
-    let cs = constraints.iter().copied().map(Constraint::from).collect();
+    let cs = constraints.iter().cloned().map(Constraint::from).collect();
     Ok(Ok((solved, duration_per_iter, cs)))
 }
 
@@ -179,7 +179,7 @@ fn print_unsatisfied(unsatisfied: &[usize], constraints: &[Constraint]) {
         let err = "Not all constraints were satisfied:".red();
         println!("{err}");
         for constraint_index in unsatisfied {
-            let constraint = constraints[*constraint_index];
+            let constraint = constraints[*constraint_index].clone();
             println!("\t{constraint_index}: {constraint:?}");
         }
     }

--- a/ezpz/src/constraint_request.rs
+++ b/ezpz/src/constraint_request.rs
@@ -8,7 +8,7 @@ use crate::Constraint;
 /// let priority = 3;
 /// let constraint_req = ConstraintRequest::new(constraint, priority);
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ConstraintRequest {
     /// The constraint itself.
@@ -86,15 +86,15 @@ mod tests {
         let custom = ConstraintRequest::new(constraint, 5);
         assert_eq!(custom.priority, 5);
 
-        let highest = ConstraintRequest::highest_priority(custom.constraint);
-        let lower = ConstraintRequest::new(custom.constraint, 40);
+        let highest = ConstraintRequest::highest_priority(custom.constraint.clone());
+        let lower = ConstraintRequest::new(custom.constraint.clone(), 40);
         assert!(highest.priority < lower.priority);
     }
 
     #[test]
     fn converts_back_to_constraint() {
         let constraint = demo_constraint();
-        let req = ConstraintRequest::new(constraint, 1);
+        let req = ConstraintRequest::new(constraint.clone(), 1);
 
         let Constraint::Fixed(id, value) = Constraint::from(req) else {
             panic!();

--- a/ezpz/src/constraint_request.rs
+++ b/ezpz/src/constraint_request.rs
@@ -87,7 +87,7 @@ mod tests {
         assert_eq!(custom.priority, 5);
 
         let highest = ConstraintRequest::highest_priority(custom.constraint.clone());
-        let lower = ConstraintRequest::new(custom.constraint.clone(), 40);
+        let lower = ConstraintRequest::new(custom.constraint, 40);
         assert!(highest.priority < lower.priority);
     }
 

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -2955,6 +2955,7 @@ fn evaluate_control_point_spline(
     })
 }
 
+#[allow(clippy::struct_field_names)]
 struct PointLineDistancePartials {
     d_point_x: f64,
     d_point_y: f64,

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -12,7 +12,7 @@ use std::f64::consts::PI;
 /// existing constraints.
 mod composite;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct ConstraintEntry<'c> {
     /// The constraint itself.
     pub constraint: &'c Constraint,
@@ -29,7 +29,7 @@ impl AsRef<Constraint> for ConstraintEntry<'_> {
 }
 
 /// Each geometric constraint we support.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 pub enum Constraint {
@@ -86,6 +86,12 @@ pub enum Constraint {
     ArcLength(DatumCircularArc, f64),
     /// The arc should span this angle.
     ArcAngle(DatumCircularArc, Angle),
+    /// The point should lie on this control-point spline.
+    PointSplineCoincident(DatumControlPointSpline, DatumPoint, DatumDistance),
+    /// The control-point spline should be tangent to the given line.
+    SplineLineTangent(DatumControlPointSpline, DatumLineSegment, DatumDistance),
+    /// The control-point spline should be tangent to the given circle.
+    SplineCircleTangent(DatumControlPointSpline, DatumCircle, DatumDistance),
 }
 
 /// Describes one value in one row of the Jacobian matrix.
@@ -193,6 +199,21 @@ impl Constraint {
             }
             Constraint::ArcLength(circular_arc, _dist) => out.extend(circular_arc.all_variables()),
             Constraint::ArcAngle(circular_arc, _angle) => out.extend(circular_arc.all_variables()),
+            Constraint::PointSplineCoincident(spline, point, parameter) => {
+                out.extend(spline.all_variables());
+                out.extend(point.all_variables());
+                out.extend(parameter.all_variables());
+            }
+            Constraint::SplineLineTangent(spline, line, parameter) => {
+                out.extend(spline.all_variables());
+                out.extend(line.all_variables());
+                out.extend(parameter.all_variables());
+            }
+            Constraint::SplineCircleTangent(spline, circle, parameter) => {
+                out.extend(spline.all_variables());
+                out.extend(circle.all_variables());
+                out.extend(parameter.all_variables());
+            }
         }
     }
 
@@ -282,6 +303,21 @@ impl Constraint {
             }
             Constraint::ArcLength(circular_arc, _dist) => out.extend(circular_arc.all_variables()),
             Constraint::ArcAngle(circular_arc, _angle) => out.extend(circular_arc.all_variables()),
+            Constraint::PointSplineCoincident(spline, point, parameter) => {
+                out.extend(spline.all_variables());
+                out.extend(point.all_variables());
+                out.extend(parameter.all_variables());
+            }
+            Constraint::SplineLineTangent(spline, line, parameter) => {
+                out.extend(spline.all_variables());
+                out.extend(line.all_variables());
+                out.extend(parameter.all_variables());
+            }
+            Constraint::SplineCircleTangent(spline, circle, parameter) => {
+                out.extend(spline.all_variables());
+                out.extend(circle.all_variables());
+                out.extend(parameter.all_variables());
+            }
         }
     }
 
@@ -390,6 +426,30 @@ impl Constraint {
                 AngleKind::Other(*angle),
             )
             .nonzeroes(row0, row1, _row2),
+            Constraint::PointSplineCoincident(spline, point, parameter) => {
+                row0.extend(spline.all_variables());
+                row0.extend(point.all_variables());
+                row0.extend(parameter.all_variables());
+                row1.extend(spline.all_variables());
+                row1.extend(point.all_variables());
+                row1.extend(parameter.all_variables());
+            }
+            Constraint::SplineLineTangent(spline, line, parameter) => {
+                row0.extend(spline.all_variables());
+                row0.extend(line.all_variables());
+                row0.extend(parameter.all_variables());
+                row1.extend(spline.all_variables());
+                row1.extend(line.all_variables());
+                row1.extend(parameter.all_variables());
+            }
+            Constraint::SplineCircleTangent(spline, circle, parameter) => {
+                row0.extend(spline.all_variables());
+                row0.extend(circle.all_variables());
+                row0.extend(parameter.all_variables());
+                row1.extend(spline.all_variables());
+                row1.extend(circle.all_variables());
+                row1.extend(parameter.all_variables());
+            }
         }
     }
 
@@ -831,6 +891,71 @@ impl Constraint {
                 _residual2,
                 degenerate,
             ),
+            Constraint::PointSplineCoincident(spline, point, parameter) => {
+                let Some(spline_eval) =
+                    evaluate_control_point_spline(current_assignments, spline, *parameter, layout)
+                else {
+                    *residual0 = 0.0;
+                    *residual1 = 0.0;
+                    *degenerate = true;
+                    return;
+                };
+                let px = current_assignments[layout.index_of(point.id_x())];
+                let py = current_assignments[layout.index_of(point.id_y())];
+                *residual0 = spline_eval.point.x - px;
+                *residual1 = spline_eval.point.y - py;
+            }
+            Constraint::SplineLineTangent(spline, line, parameter) => {
+                let Some(spline_eval) =
+                    evaluate_control_point_spline(current_assignments, spline, *parameter, layout)
+                else {
+                    *residual0 = 0.0;
+                    *residual1 = 0.0;
+                    *degenerate = true;
+                    return;
+                };
+                let p0x = current_assignments[layout.index_of(line.p0.id_x())];
+                let p0y = current_assignments[layout.index_of(line.p0.id_y())];
+                let p1x = current_assignments[layout.index_of(line.p1.id_x())];
+                let p1y = current_assignments[layout.index_of(line.p1.id_y())];
+                let dx = p1x - p0x;
+                let dy = p1y - p0y;
+                let denominator = libm::hypot(dx, dy);
+                if denominator <= EPSILON {
+                    *residual0 = 0.0;
+                    *residual1 = 0.0;
+                    *degenerate = true;
+                    return;
+                }
+
+                let (a, b, c) = inner_equation_of_line(p0x, p0y, p1x, p1y);
+                *residual0 = (a * spline_eval.point.x + b * spline_eval.point.y + c) / denominator;
+                *residual1 = spline_eval.tangent.x * dy - spline_eval.tangent.y * dx;
+            }
+            Constraint::SplineCircleTangent(spline, circle, parameter) => {
+                let Some(spline_eval) =
+                    evaluate_control_point_spline(current_assignments, spline, *parameter, layout)
+                else {
+                    *residual0 = 0.0;
+                    *residual1 = 0.0;
+                    *degenerate = true;
+                    return;
+                };
+                let cx = current_assignments[layout.index_of(circle.center.id_x())];
+                let cy = current_assignments[layout.index_of(circle.center.id_y())];
+                let radius = current_assignments[layout.index_of(circle.radius.id)];
+                let radial = spline_eval.point - V::new(cx, cy);
+                let radial_distance = radial.magnitude();
+                if radial_distance <= EPSILON {
+                    *residual0 = 0.0;
+                    *residual1 = 0.0;
+                    *degenerate = true;
+                    return;
+                }
+
+                *residual0 = radial_distance - radius;
+                *residual1 = spline_eval.tangent.dot(radial);
+            }
         }
     }
 
@@ -873,6 +998,9 @@ impl Constraint {
                 AngleKind::Other(*angle),
             )
             .residual_dim(),
+            Constraint::PointSplineCoincident(..) => 2,
+            Constraint::SplineLineTangent(..) => 2,
+            Constraint::SplineCircleTangent(..) => 2,
         }
     }
 
@@ -2092,6 +2220,200 @@ impl Constraint {
                 AngleKind::Other(*angle),
             )
             .jacobian_rows(layout, current_assignments, row0, row1, _row2, degenerate),
+            Constraint::PointSplineCoincident(spline, point, parameter) => {
+                let Some(spline_eval) =
+                    evaluate_control_point_spline(current_assignments, spline, *parameter, layout)
+                else {
+                    *degenerate = true;
+                    return;
+                };
+
+                for (index, control) in spline.controls.iter().enumerate() {
+                    row0.push(JacobianVar {
+                        id: control.id_x(),
+                        partial_derivative: spline_eval.basis[index],
+                    });
+                    row1.push(JacobianVar {
+                        id: control.id_y(),
+                        partial_derivative: spline_eval.basis[index],
+                    });
+                }
+                row0.push(JacobianVar {
+                    id: point.id_x(),
+                    partial_derivative: -1.0,
+                });
+                row1.push(JacobianVar {
+                    id: point.id_y(),
+                    partial_derivative: -1.0,
+                });
+                row0.push(JacobianVar {
+                    id: parameter.id,
+                    partial_derivative: spline_eval.tangent.x * spline_eval.dparameter_draw,
+                });
+                row1.push(JacobianVar {
+                    id: parameter.id,
+                    partial_derivative: spline_eval.tangent.y * spline_eval.dparameter_draw,
+                });
+            }
+            Constraint::SplineLineTangent(spline, line, parameter) => {
+                let Some(spline_eval) =
+                    evaluate_control_point_spline(current_assignments, spline, *parameter, layout)
+                else {
+                    *degenerate = true;
+                    return;
+                };
+                let p0x = current_assignments[layout.index_of(line.p0.id_x())];
+                let p0y = current_assignments[layout.index_of(line.p0.id_y())];
+                let p1x = current_assignments[layout.index_of(line.p1.id_x())];
+                let p1y = current_assignments[layout.index_of(line.p1.id_y())];
+                let dx = p1x - p0x;
+                let dy = p1y - p0y;
+                let Some(distance_partials) =
+                    point_line_distance_partials(spline_eval.point.x, spline_eval.point.y, p0x, p0y, p1x, p1y)
+                else {
+                    *degenerate = true;
+                    return;
+                };
+
+                for (index, control) in spline.controls.iter().enumerate() {
+                    row0.push(JacobianVar {
+                        id: control.id_x(),
+                        partial_derivative: distance_partials.d_point_x * spline_eval.basis[index],
+                    });
+                    row0.push(JacobianVar {
+                        id: control.id_y(),
+                        partial_derivative: distance_partials.d_point_y * spline_eval.basis[index],
+                    });
+                    row1.push(JacobianVar {
+                        id: control.id_x(),
+                        partial_derivative: spline_eval.basis_first[index] * dy,
+                    });
+                    row1.push(JacobianVar {
+                        id: control.id_y(),
+                        partial_derivative: -spline_eval.basis_first[index] * dx,
+                    });
+                }
+                row0.extend([
+                    JacobianVar {
+                        id: line.p0.id_x(),
+                        partial_derivative: distance_partials.d_p0_x,
+                    },
+                    JacobianVar {
+                        id: line.p0.id_y(),
+                        partial_derivative: distance_partials.d_p0_y,
+                    },
+                    JacobianVar {
+                        id: line.p1.id_x(),
+                        partial_derivative: distance_partials.d_p1_x,
+                    },
+                    JacobianVar {
+                        id: line.p1.id_y(),
+                        partial_derivative: distance_partials.d_p1_y,
+                    },
+                    JacobianVar {
+                        id: parameter.id,
+                        partial_derivative: (distance_partials.d_point_x * spline_eval.tangent.x
+                            + distance_partials.d_point_y * spline_eval.tangent.y)
+                            * spline_eval.dparameter_draw,
+                    },
+                ]);
+                row1.extend([
+                    JacobianVar {
+                        id: line.p0.id_x(),
+                        partial_derivative: spline_eval.tangent.y,
+                    },
+                    JacobianVar {
+                        id: line.p0.id_y(),
+                        partial_derivative: -spline_eval.tangent.x,
+                    },
+                    JacobianVar {
+                        id: line.p1.id_x(),
+                        partial_derivative: -spline_eval.tangent.y,
+                    },
+                    JacobianVar {
+                        id: line.p1.id_y(),
+                        partial_derivative: spline_eval.tangent.x,
+                    },
+                    JacobianVar {
+                        id: parameter.id,
+                        partial_derivative: (spline_eval.acceleration.x * dy - spline_eval.acceleration.y * dx)
+                            * spline_eval.dparameter_draw,
+                    },
+                ]);
+            }
+            Constraint::SplineCircleTangent(spline, circle, parameter) => {
+                let Some(spline_eval) =
+                    evaluate_control_point_spline(current_assignments, spline, *parameter, layout)
+                else {
+                    *degenerate = true;
+                    return;
+                };
+                let cx = current_assignments[layout.index_of(circle.center.id_x())];
+                let cy = current_assignments[layout.index_of(circle.center.id_y())];
+                let radial = spline_eval.point - V::new(cx, cy);
+                let radial_distance = radial.magnitude();
+                if radial_distance <= EPSILON {
+                    *degenerate = true;
+                    return;
+                }
+                let unit_radial = V::new(radial.x / radial_distance, radial.y / radial_distance);
+
+                for (index, control) in spline.controls.iter().enumerate() {
+                    row0.push(JacobianVar {
+                        id: control.id_x(),
+                        partial_derivative: unit_radial.x * spline_eval.basis[index],
+                    });
+                    row0.push(JacobianVar {
+                        id: control.id_y(),
+                        partial_derivative: unit_radial.y * spline_eval.basis[index],
+                    });
+                    row1.push(JacobianVar {
+                        id: control.id_x(),
+                        partial_derivative: spline_eval.basis_first[index] * radial.x
+                            + spline_eval.tangent.x * spline_eval.basis[index],
+                    });
+                    row1.push(JacobianVar {
+                        id: control.id_y(),
+                        partial_derivative: spline_eval.basis_first[index] * radial.y
+                            + spline_eval.tangent.y * spline_eval.basis[index],
+                    });
+                }
+
+                row0.extend([
+                    JacobianVar {
+                        id: circle.center.id_x(),
+                        partial_derivative: -unit_radial.x,
+                    },
+                    JacobianVar {
+                        id: circle.center.id_y(),
+                        partial_derivative: -unit_radial.y,
+                    },
+                    JacobianVar {
+                        id: circle.radius.id,
+                        partial_derivative: -1.0,
+                    },
+                    JacobianVar {
+                        id: parameter.id,
+                        partial_derivative: unit_radial.dot(spline_eval.tangent) * spline_eval.dparameter_draw,
+                    },
+                ]);
+                row1.extend([
+                    JacobianVar {
+                        id: circle.center.id_x(),
+                        partial_derivative: -spline_eval.tangent.x,
+                    },
+                    JacobianVar {
+                        id: circle.center.id_y(),
+                        partial_derivative: -spline_eval.tangent.y,
+                    },
+                    JacobianVar {
+                        id: parameter.id,
+                        partial_derivative: (spline_eval.acceleration.dot(radial)
+                            + spline_eval.tangent.dot(spline_eval.tangent))
+                            * spline_eval.dparameter_draw,
+                    },
+                ]);
+            }
         }
     }
 
@@ -2127,6 +2449,9 @@ impl Constraint {
             Constraint::PointArcCoincident(..) => "PointArcCoincident",
             Constraint::ArcLength(..) => "ArcLength",
             Constraint::ArcAngle(..) => "ArcAngle",
+            Constraint::PointSplineCoincident(..) => "PointSplineCoincident",
+            Constraint::SplineLineTangent(..) => "SplineLineTangent",
+            Constraint::SplineCircleTangent(..) => "SplineCircleTangent",
         }
     }
 }
@@ -2446,6 +2771,195 @@ fn rotation_for_angle_kind(angle_kind: AngleKind) -> Rotation2 {
         AngleKind::Perpendicular => Rotation2::from_sincos(1.0, 0.0),
         AngleKind::Other(angle) => Rotation2::from_angle_radians(angle.to_radians()),
     }
+}
+
+fn build_open_uniform_knot_vector(control_count: usize, degree: usize) -> Vec<f64> {
+    let order = degree + 1;
+    let knot_count = control_count + order;
+    let interior_count = knot_count.saturating_sub(2 * order);
+    let mut knots = vec![0.0; knot_count];
+    for (index, knot) in knots.iter_mut().enumerate() {
+        if index < order {
+            *knot = 0.0;
+        } else if index >= knot_count - order {
+            *knot = 1.0;
+        } else {
+            *knot = (index - degree) as f64 / (interior_count + 1) as f64;
+        }
+    }
+    knots
+}
+
+fn bspline_basis(i: usize, degree: usize, u: f64, knots: &[f64], control_count: usize) -> f64 {
+    if degree == 0 {
+        let in_span = knots[i] <= u && u < knots[i + 1];
+        let is_last = i == control_count - 1 && u >= knots[control_count];
+        return if in_span || is_last { 1.0 } else { 0.0 };
+    }
+
+    let mut value = 0.0;
+    let left_denominator = knots[i + degree] - knots[i];
+    if left_denominator.abs() > EPSILON {
+        value += ((u - knots[i]) / left_denominator) * bspline_basis(i, degree - 1, u, knots, control_count);
+    }
+
+    let right_denominator = knots[i + degree + 1] - knots[i + 1];
+    if right_denominator.abs() > EPSILON {
+        value += ((knots[i + degree + 1] - u) / right_denominator)
+            * bspline_basis(i + 1, degree - 1, u, knots, control_count);
+    }
+
+    value
+}
+
+fn bspline_basis_first_derivative(i: usize, degree: usize, u: f64, knots: &[f64], control_count: usize) -> f64 {
+    if degree == 0 {
+        return 0.0;
+    }
+
+    let mut value = 0.0;
+    let left_denominator = knots[i + degree] - knots[i];
+    if left_denominator.abs() > EPSILON {
+        value += degree as f64 / left_denominator * bspline_basis(i, degree - 1, u, knots, control_count);
+    }
+
+    let right_denominator = knots[i + degree + 1] - knots[i + 1];
+    if right_denominator.abs() > EPSILON {
+        value -= degree as f64 / right_denominator * bspline_basis(i + 1, degree - 1, u, knots, control_count);
+    }
+
+    value
+}
+
+fn bspline_basis_second_derivative(i: usize, degree: usize, u: f64, knots: &[f64], control_count: usize) -> f64 {
+    if degree <= 1 {
+        return 0.0;
+    }
+
+    let mut value = 0.0;
+    let left_denominator = knots[i + degree] - knots[i];
+    if left_denominator.abs() > EPSILON {
+        value += degree as f64 / left_denominator
+            * bspline_basis_first_derivative(i, degree - 1, u, knots, control_count);
+    }
+
+    let right_denominator = knots[i + degree + 1] - knots[i + 1];
+    if right_denominator.abs() > EPSILON {
+        value -= degree as f64 / right_denominator
+            * bspline_basis_first_derivative(i + 1, degree - 1, u, knots, control_count);
+    }
+
+    value
+}
+
+struct SplineEvaluation {
+    point: V,
+    tangent: V,
+    acceleration: V,
+    basis: Vec<f64>,
+    basis_first: Vec<f64>,
+    dparameter_draw: f64,
+}
+
+fn evaluate_control_point_spline(
+    current_assignments: &[f64],
+    spline: &DatumControlPointSpline,
+    raw_parameter: DatumDistance,
+    layout: &Layout,
+) -> Option<SplineEvaluation> {
+    if spline.controls.len() < 2 {
+        return None;
+    }
+
+    let effective_degree = spline.degree.clamp(1, spline.controls.len() - 1);
+    let raw = current_assignments[layout.index_of(raw_parameter.id)];
+    let (parameter, dparameter_draw) = if raw < 0.0 {
+        (0.0, 0.0)
+    } else if raw > 1.0 {
+        (1.0, 0.0)
+    } else {
+        (raw, 1.0)
+    };
+    let knots = build_open_uniform_knot_vector(spline.controls.len(), effective_degree);
+
+    let mut point = V::new(0.0, 0.0);
+    let mut tangent = V::new(0.0, 0.0);
+    let mut acceleration = V::new(0.0, 0.0);
+    let mut basis = Vec::with_capacity(spline.controls.len());
+    let mut basis_first = Vec::with_capacity(spline.controls.len());
+
+    for (index, control) in spline.controls.iter().enumerate() {
+        let control_x = current_assignments[layout.index_of(control.id_x())];
+        let control_y = current_assignments[layout.index_of(control.id_y())];
+        let basis_value = bspline_basis(index, effective_degree, parameter, &knots, spline.controls.len());
+        let basis_first_value =
+            bspline_basis_first_derivative(index, effective_degree, parameter, &knots, spline.controls.len());
+        let basis_second_value =
+            bspline_basis_second_derivative(index, effective_degree, parameter, &knots, spline.controls.len());
+
+        point.x += basis_value * control_x;
+        point.y += basis_value * control_y;
+        tangent.x += basis_first_value * control_x;
+        tangent.y += basis_first_value * control_y;
+        acceleration.x += basis_second_value * control_x;
+        acceleration.y += basis_second_value * control_y;
+        basis.push(basis_value);
+        basis_first.push(basis_first_value);
+    }
+
+    Some(SplineEvaluation {
+        point,
+        tangent,
+        acceleration,
+        basis,
+        basis_first,
+        dparameter_draw,
+    })
+}
+
+struct PointLineDistancePartials {
+    d_point_x: f64,
+    d_point_y: f64,
+    d_p0_x: f64,
+    d_p0_y: f64,
+    d_p1_x: f64,
+    d_p1_y: f64,
+}
+
+fn point_line_distance_partials(px: f64, py: f64, p0x: f64, p0y: f64, p1x: f64, p1y: f64) -> Option<PointLineDistancePartials> {
+    let euclid_dist = libm::hypot(-p0x + p1x, p0y - p1y);
+    if euclid_dist <= EPSILON {
+        return None;
+    }
+
+    let d_point_x = (p0y - p1y) / euclid_dist;
+    let d_point_y = (-p0x + p1x) / euclid_dist;
+    let denom = ((-p0x + p1x).powi(2) + (p0y - p1y).powi(2)).powf(1.5);
+    if denom <= EPSILON {
+        return None;
+    }
+
+    let d_p0_x =
+        ((-p0x + p1x) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
+            + (p1y - py) / euclid_dist;
+    let d_p0_y =
+        ((-p0y + p1y) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
+            + (-p1x + px) / euclid_dist;
+    let d_p1_x =
+        ((p0x - p1x) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
+            + (-p0y + py) / euclid_dist;
+    let d_p1_y =
+        ((p0y - p1y) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
+            + (p0x - px) / euclid_dist;
+
+    Some(PointLineDistancePartials {
+        d_point_x,
+        d_point_y,
+        d_p0_x,
+        d_p0_y,
+        d_p1_x,
+        d_p1_y,
+    })
 }
 
 #[cfg(test)]

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -2268,9 +2268,14 @@ impl Constraint {
                 let p1y = current_assignments[layout.index_of(line.p1.id_y())];
                 let dx = p1x - p0x;
                 let dy = p1y - p0y;
-                let Some(distance_partials) =
-                    point_line_distance_partials(spline_eval.point.x, spline_eval.point.y, p0x, p0y, p1x, p1y)
-                else {
+                let Some(distance_partials) = point_line_distance_partials(
+                    spline_eval.point.x,
+                    spline_eval.point.y,
+                    p0x,
+                    p0y,
+                    p1x,
+                    p1y,
+                ) else {
                     *degenerate = true;
                     return;
                 };
@@ -2336,7 +2341,8 @@ impl Constraint {
                     },
                     JacobianVar {
                         id: parameter.id,
-                        partial_derivative: (spline_eval.acceleration.x * dy - spline_eval.acceleration.y * dx)
+                        partial_derivative: (spline_eval.acceleration.x * dy
+                            - spline_eval.acceleration.y * dx)
                             * spline_eval.dparameter_draw,
                     },
                 ]);
@@ -2394,7 +2400,8 @@ impl Constraint {
                     },
                     JacobianVar {
                         id: parameter.id,
-                        partial_derivative: unit_radial.dot(spline_eval.tangent) * spline_eval.dparameter_draw,
+                        partial_derivative: unit_radial.dot(spline_eval.tangent)
+                            * spline_eval.dparameter_draw,
                     },
                 ]);
                 row1.extend([
@@ -2800,7 +2807,8 @@ fn bspline_basis(i: usize, degree: usize, u: f64, knots: &[f64], control_count: 
     let mut value = 0.0;
     let left_denominator = knots[i + degree] - knots[i];
     if left_denominator.abs() > EPSILON {
-        value += ((u - knots[i]) / left_denominator) * bspline_basis(i, degree - 1, u, knots, control_count);
+        value += ((u - knots[i]) / left_denominator)
+            * bspline_basis(i, degree - 1, u, knots, control_count);
     }
 
     let right_denominator = knots[i + degree + 1] - knots[i + 1];
@@ -2812,7 +2820,13 @@ fn bspline_basis(i: usize, degree: usize, u: f64, knots: &[f64], control_count: 
     value
 }
 
-fn bspline_basis_first_derivative(i: usize, degree: usize, u: f64, knots: &[f64], control_count: usize) -> f64 {
+fn bspline_basis_first_derivative(
+    i: usize,
+    degree: usize,
+    u: f64,
+    knots: &[f64],
+    control_count: usize,
+) -> f64 {
     if degree == 0 {
         return 0.0;
     }
@@ -2820,18 +2834,26 @@ fn bspline_basis_first_derivative(i: usize, degree: usize, u: f64, knots: &[f64]
     let mut value = 0.0;
     let left_denominator = knots[i + degree] - knots[i];
     if left_denominator.abs() > EPSILON {
-        value += degree as f64 / left_denominator * bspline_basis(i, degree - 1, u, knots, control_count);
+        value += degree as f64 / left_denominator
+            * bspline_basis(i, degree - 1, u, knots, control_count);
     }
 
     let right_denominator = knots[i + degree + 1] - knots[i + 1];
     if right_denominator.abs() > EPSILON {
-        value -= degree as f64 / right_denominator * bspline_basis(i + 1, degree - 1, u, knots, control_count);
+        value -= degree as f64 / right_denominator
+            * bspline_basis(i + 1, degree - 1, u, knots, control_count);
     }
 
     value
 }
 
-fn bspline_basis_second_derivative(i: usize, degree: usize, u: f64, knots: &[f64], control_count: usize) -> f64 {
+fn bspline_basis_second_derivative(
+    i: usize,
+    degree: usize,
+    u: f64,
+    knots: &[f64],
+    control_count: usize,
+) -> f64 {
     if degree <= 1 {
         return 0.0;
     }
@@ -2891,11 +2913,27 @@ fn evaluate_control_point_spline(
     for (index, control) in spline.controls.iter().enumerate() {
         let control_x = current_assignments[layout.index_of(control.id_x())];
         let control_y = current_assignments[layout.index_of(control.id_y())];
-        let basis_value = bspline_basis(index, effective_degree, parameter, &knots, spline.controls.len());
-        let basis_first_value =
-            bspline_basis_first_derivative(index, effective_degree, parameter, &knots, spline.controls.len());
-        let basis_second_value =
-            bspline_basis_second_derivative(index, effective_degree, parameter, &knots, spline.controls.len());
+        let basis_value = bspline_basis(
+            index,
+            effective_degree,
+            parameter,
+            &knots,
+            spline.controls.len(),
+        );
+        let basis_first_value = bspline_basis_first_derivative(
+            index,
+            effective_degree,
+            parameter,
+            &knots,
+            spline.controls.len(),
+        );
+        let basis_second_value = bspline_basis_second_derivative(
+            index,
+            effective_degree,
+            parameter,
+            &knots,
+            spline.controls.len(),
+        );
 
         point.x += basis_value * control_x;
         point.y += basis_value * control_y;
@@ -2926,7 +2964,14 @@ struct PointLineDistancePartials {
     d_p1_y: f64,
 }
 
-fn point_line_distance_partials(px: f64, py: f64, p0x: f64, p0y: f64, p1x: f64, p1y: f64) -> Option<PointLineDistancePartials> {
+fn point_line_distance_partials(
+    px: f64,
+    py: f64,
+    p0x: f64,
+    p0y: f64,
+    p1x: f64,
+    p1y: f64,
+) -> Option<PointLineDistancePartials> {
     let euclid_dist = libm::hypot(-p0x + p1x, p0y - p1y);
     if euclid_dist <= EPSILON {
         return None;
@@ -2939,18 +2984,18 @@ fn point_line_distance_partials(px: f64, py: f64, p0x: f64, p0y: f64, p1x: f64, 
         return None;
     }
 
-    let d_p0_x =
-        ((-p0x + p1x) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
-            + (p1y - py) / euclid_dist;
-    let d_p0_y =
-        ((-p0y + p1y) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
-            + (-p1x + px) / euclid_dist;
-    let d_p1_x =
-        ((p0x - p1x) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
-            + (-p0y + py) / euclid_dist;
-    let d_p1_y =
-        ((p0y - p1y) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x))) / denom
-            + (p0x - px) / euclid_dist;
+    let d_p0_x = ((-p0x + p1x) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x)))
+        / denom
+        + (p1y - py) / euclid_dist;
+    let d_p0_y = ((-p0y + p1y) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x)))
+        / denom
+        + (-p1x + px) / euclid_dist;
+    let d_p1_x = ((p0x - p1x) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x)))
+        / denom
+        + (-p0y + py) / euclid_dist;
+    let d_p1_y = ((p0y - p1y) * (p0x * p1y - p0y * p1x + px * (p0y - p1y) + py * (-p0x + p1x)))
+        / denom
+        + (p0x - px) / euclid_dist;
 
     Some(PointLineDistancePartials {
         d_point_x,

--- a/ezpz/src/datatypes.rs
+++ b/ezpz/src/datatypes.rs
@@ -136,5 +136,14 @@ mod tests {
             arc.all_variables().into_iter().collect::<Vec<_>>(),
             vec![2, 3, 6, 7, 0, 1]
         );
+
+        let spline = DatumControlPointSpline {
+            controls: vec![p0, p1, DatumPoint::new_xy(6, 7)].into_boxed_slice(),
+            degree: 2,
+        };
+        assert_eq!(
+            spline.all_variables().into_iter().collect::<Vec<_>>(),
+            vec![0, 1, 2, 3, 6, 7]
+        );
     }
 }

--- a/ezpz/src/datatypes/inputs.rs
+++ b/ezpz/src/datatypes/inputs.rs
@@ -191,3 +191,23 @@ impl Datum for DatumCircularArc {
         ]
     }
 }
+
+/// Open-uniform control-point spline.
+/// Control points can be determined by the constraint solver.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct DatumControlPointSpline {
+    /// Ordered control points of the spline.
+    pub controls: Box<[DatumPoint]>,
+    /// Spline degree.
+    pub degree: usize,
+}
+
+impl Datum for DatumControlPointSpline {
+    fn all_variables(&self) -> impl IntoIterator<Item = Id> {
+        self.controls
+            .iter()
+            .flat_map(|point| [point.id_x(), point.id_y()])
+            .collect::<Vec<_>>()
+    }
+}

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -4,7 +4,10 @@ use super::*;
 use crate::{
     datatypes::{
         Angle, AngleKind,
-        inputs::{DatumCircularArc, DatumPoint},
+        inputs::{
+            DatumCircle, DatumCircularArc, DatumControlPointSpline, DatumDistance, DatumLineSegment,
+            DatumPoint,
+        },
         outputs::Point,
     },
     textual::{OutcomeAnalysis, Problem},
@@ -704,7 +707,7 @@ fn arc_length_ccw_over_pi() {
         arc_end_guess,
     );
 
-    assert!(outcome.is_satisfied());
+    assert!(outcome.is_satisfied(), "{outcome:#?}");
 
     let solved_end_x = outcome.final_values[arc.end.id_x() as usize];
     let solved_end_y = outcome.final_values[arc.end.id_y() as usize];
@@ -845,8 +848,8 @@ fn strange_nonconvergence() {
         ConstraintRequest::highest_priority(Constraint::PointsCoincident(r, s)),
         ConstraintRequest::highest_priority(Constraint::PointsCoincident(q, p)),
         ConstraintRequest::highest_priority(Constraint::LinesEqualLength(
-            datatypes::inputs::DatumLineSegment { p0: q, p1: r },
-            datatypes::inputs::DatumLineSegment { p0: s, p1: t },
+            DatumLineSegment { p0: q, p1: r },
+            DatumLineSegment { p0: s, p1: t },
         )),
     ];
     let initial_guesses = vec![
@@ -1425,4 +1428,186 @@ fn lines_angle_sign_check() {
             assert_nearly_eq(u.signed_angle(v), test_case.angle);
         }
     }
+}
+
+#[test]
+fn point_spline_coincident_solves_internal_parameter() {
+    let mut ids = IdGenerator::default();
+    let p0 = DatumPoint::new(&mut ids);
+    let p1 = DatumPoint::new(&mut ids);
+    let p2 = DatumPoint::new(&mut ids);
+    let point = DatumPoint::new(&mut ids);
+    let parameter = DatumDistance::new(ids.next_id());
+    let spline = DatumControlPointSpline {
+        controls: Box::new([p0, p1, p2]),
+        degree: 2,
+    };
+
+    let constraints = vec![
+        ConstraintRequest::highest_priority(Constraint::PointSplineCoincident(spline.clone(), point, parameter)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 1.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_y(), 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_x(), 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_y(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(point.id_x(), 1.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(point.id_y(), 1.0)),
+    ];
+    let initial_guesses = vec![
+        (p0.id_x(), 0.0),
+        (p0.id_y(), 0.0),
+        (p1.id_x(), 1.0),
+        (p1.id_y(), 2.0),
+        (p2.id_x(), 2.0),
+        (p2.id_y(), 0.0),
+        (point.id_x(), 1.0),
+        (point.id_y(), 1.0),
+        (parameter.id, 0.6),
+    ];
+
+    let outcome = solve(&constraints, initial_guesses, Config::default()).unwrap();
+    assert!(outcome.is_satisfied());
+    assert_nearly_eq(outcome.final_values[parameter.id as usize], 0.5);
+}
+
+#[test]
+fn spline_line_tangent_solves_internal_parameter() {
+    let mut ids = IdGenerator::default();
+    let p0 = DatumPoint::new(&mut ids);
+    let p1 = DatumPoint::new(&mut ids);
+    let p2 = DatumPoint::new(&mut ids);
+    let line_start = DatumPoint::new(&mut ids);
+    let line_end = DatumPoint::new(&mut ids);
+    let parameter = DatumDistance::new(ids.next_id());
+    let spline = DatumControlPointSpline {
+        controls: Box::new([p0, p1, p2]),
+        degree: 2,
+    };
+    let line = DatumLineSegment::new(line_start, line_end);
+
+    let constraints = vec![
+        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(spline.clone(), line, parameter)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 1.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_y(), 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_x(), 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_y(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(line_start.id_x(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(line_start.id_y(), 1.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(line_end.id_x(), 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(line_end.id_y(), 1.0)),
+    ];
+    let initial_guesses = vec![
+        (p0.id_x(), 0.0),
+        (p0.id_y(), 0.0),
+        (p1.id_x(), 1.0),
+        (p1.id_y(), 2.0),
+        (p2.id_x(), 2.0),
+        (p2.id_y(), 0.0),
+        (line_start.id_x(), 0.0),
+        (line_start.id_y(), 1.0),
+        (line_end.id_x(), 2.0),
+        (line_end.id_y(), 1.0),
+        (parameter.id, 0.4),
+    ];
+
+    let outcome = solve(&constraints, initial_guesses, Config::default()).unwrap();
+    assert!(outcome.is_satisfied());
+    assert_nearly_eq(outcome.final_values[parameter.id as usize], 0.5);
+}
+
+#[test]
+fn spline_line_tangent_can_solve_at_endpoint() {
+    let mut ids = IdGenerator::default();
+    let p0 = DatumPoint::new(&mut ids);
+    let p1 = DatumPoint::new(&mut ids);
+    let p2 = DatumPoint::new(&mut ids);
+    let p3 = DatumPoint::new(&mut ids);
+    let line_start = DatumPoint::new(&mut ids);
+    let line_end = DatumPoint::new(&mut ids);
+    let parameter = DatumDistance::new(ids.next_id());
+    let spline = DatumControlPointSpline {
+        controls: Box::new([p0, p1, p2, p3]),
+        degree: 3,
+    };
+    let line = DatumLineSegment::new(line_start, line_end);
+
+    let constraints = vec![
+        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(spline.clone(), line, parameter)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), -78.18)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), -16.4)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 46.85)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_y(), 4.95)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_x(), 83.55)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_y(), 92.71)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p3.id_x(), -73.29)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p3.id_y(), 92.53)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(line_start.id_x(), -78.18)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(line_start.id_y(), -16.4)),
+    ];
+    let initial_guesses = vec![
+        (p0.id_x(), -78.18),
+        (p0.id_y(), -16.4),
+        (p1.id_x(), 46.85),
+        (p1.id_y(), 4.95),
+        (p2.id_x(), 83.55),
+        (p2.id_y(), 92.71),
+        (p3.id_x(), -73.29),
+        (p3.id_y(), 92.53),
+        (line_start.id_x(), -78.18),
+        (line_start.id_y(), -16.4),
+        (line_end.id_x(), -120.14),
+        (line_end.id_y(), -28.1),
+        (parameter.id, 0.5),
+    ];
+
+    let outcome = solve(&constraints, initial_guesses, Config::default()).unwrap();
+    assert!(outcome.is_satisfied(), "{outcome:#?}");
+}
+
+#[test]
+fn spline_circle_tangent_solves_internal_parameter() {
+    let mut ids = IdGenerator::default();
+    let p0 = DatumPoint::new(&mut ids);
+    let p1 = DatumPoint::new(&mut ids);
+    let p2 = DatumPoint::new(&mut ids);
+    let center = DatumPoint::new(&mut ids);
+    let radius = DatumDistance::new(ids.next_id());
+    let parameter = DatumDistance::new(ids.next_id());
+    let spline = DatumControlPointSpline {
+        controls: Box::new([p0, p1, p2]),
+        degree: 2,
+    };
+    let circle = DatumCircle { center, radius };
+
+    let constraints = vec![
+        ConstraintRequest::highest_priority(Constraint::SplineCircleTangent(spline.clone(), circle, parameter)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 1.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_y(), 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_x(), 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p2.id_y(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(center.id_x(), 1.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(center.id_y(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(radius.id, 1.0)),
+    ];
+    let initial_guesses = vec![
+        (p0.id_x(), 0.0),
+        (p0.id_y(), 0.0),
+        (p1.id_x(), 1.0),
+        (p1.id_y(), 2.0),
+        (p2.id_x(), 2.0),
+        (p2.id_y(), 0.0),
+        (center.id_x(), 1.0),
+        (center.id_y(), 0.0),
+        (radius.id, 1.0),
+        (parameter.id, 0.5),
+    ];
+
+    let outcome = solve(&constraints, initial_guesses, Config::default()).unwrap();
+    assert!(outcome.is_satisfied(), "{outcome:#?}");
+    assert_nearly_eq(outcome.final_values[parameter.id as usize], 0.5);
 }

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -5,8 +5,8 @@ use crate::{
     datatypes::{
         Angle, AngleKind,
         inputs::{
-            DatumCircle, DatumCircularArc, DatumControlPointSpline, DatumDistance, DatumLineSegment,
-            DatumPoint,
+            DatumCircle, DatumCircularArc, DatumControlPointSpline, DatumDistance,
+            DatumLineSegment, DatumPoint,
         },
         outputs::Point,
     },
@@ -1444,7 +1444,11 @@ fn point_spline_coincident_solves_internal_parameter() {
     };
 
     let constraints = vec![
-        ConstraintRequest::highest_priority(Constraint::PointSplineCoincident(spline.clone(), point, parameter)),
+        ConstraintRequest::highest_priority(Constraint::PointSplineCoincident(
+            spline.clone(),
+            point,
+            parameter,
+        )),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 1.0)),
@@ -1487,7 +1491,11 @@ fn spline_line_tangent_solves_internal_parameter() {
     let line = DatumLineSegment::new(line_start, line_end);
 
     let constraints = vec![
-        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(spline.clone(), line, parameter)),
+        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(
+            spline.clone(),
+            line,
+            parameter,
+        )),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 1.0)),
@@ -1535,7 +1543,11 @@ fn spline_line_tangent_can_solve_at_endpoint() {
     let line = DatumLineSegment::new(line_start, line_end);
 
     let constraints = vec![
-        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(spline.clone(), line, parameter)),
+        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(
+            spline.clone(),
+            line,
+            parameter,
+        )),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), -78.18)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), -16.4)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 46.85)),
@@ -1583,7 +1595,11 @@ fn spline_circle_tangent_solves_internal_parameter() {
     let circle = DatumCircle { center, radius };
 
     let constraints = vec![
-        ConstraintRequest::highest_priority(Constraint::SplineCircleTangent(spline.clone(), circle, parameter)),
+        ConstraintRequest::highest_priority(Constraint::SplineCircleTangent(
+            spline.clone(),
+            circle,
+            parameter,
+        )),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 1.0)),

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -1445,9 +1445,7 @@ fn point_spline_coincident_solves_internal_parameter() {
 
     let constraints = vec![
         ConstraintRequest::highest_priority(Constraint::PointSplineCoincident(
-            spline.clone(),
-            point,
-            parameter,
+            spline, point, parameter,
         )),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
@@ -1491,11 +1489,7 @@ fn spline_line_tangent_solves_internal_parameter() {
     let line = DatumLineSegment::new(line_start, line_end);
 
     let constraints = vec![
-        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(
-            spline.clone(),
-            line,
-            parameter,
-        )),
+        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(spline, line, parameter)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 1.0)),
@@ -1543,11 +1537,7 @@ fn spline_line_tangent_can_solve_at_endpoint() {
     let line = DatumLineSegment::new(line_start, line_end);
 
     let constraints = vec![
-        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(
-            spline.clone(),
-            line,
-            parameter,
-        )),
+        ConstraintRequest::highest_priority(Constraint::SplineLineTangent(spline, line, parameter)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), -78.18)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), -16.4)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p1.id_x(), 46.85)),
@@ -1596,9 +1586,7 @@ fn spline_circle_tangent_solves_internal_parameter() {
 
     let constraints = vec![
         ConstraintRequest::highest_priority(Constraint::SplineCircleTangent(
-            spline.clone(),
-            circle,
-            parameter,
+            spline, circle, parameter,
         )),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_x(), 0.0)),
         ConstraintRequest::highest_priority(Constraint::Fixed(p0.id_y(), 0.0)),

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -1474,6 +1474,36 @@ fn point_spline_coincident_solves_internal_parameter() {
 }
 
 #[test]
+fn textual_point_spline_coincident_solves() {
+    let txt = r#"# constraints
+point p0
+point p1
+point p2
+point q
+spline s(2, p0, p1, p2)
+point_spline_coincident(q, s)
+p0 = (0, 0)
+p1 = (1, 2)
+p2 = (2, 0)
+q = (1, 1)
+
+# guesses
+p0 roughly (0, 0)
+p1 roughly (1, 2)
+p2 roughly (2, 0)
+q roughly (1, 1)
+"#;
+    let problem = parse_problem(txt);
+    let outcome = problem
+        .to_constraint_system()
+        .unwrap()
+        .solve_with_config_analysis(Config::default())
+        .unwrap();
+    assert!(outcome.is_satisfied());
+    assert_eq!(outcome.get_point("q"), Some(Point { x: 1.0, y: 1.0 }));
+}
+
+#[test]
 fn spline_line_tangent_solves_internal_parameter() {
     let mut ids = IdGenerator::default();
     let p0 = DatumPoint::new(&mut ids);
@@ -1518,6 +1548,38 @@ fn spline_line_tangent_solves_internal_parameter() {
     let outcome = solve(&constraints, initial_guesses, Config::default()).unwrap();
     assert!(outcome.is_satisfied());
     assert_nearly_eq(outcome.final_values[parameter.id as usize], 0.5);
+}
+
+#[test]
+fn textual_spline_line_tangent_solves() {
+    let txt = r#"# constraints
+point p0
+point p1
+point p2
+point l0
+point l1
+spline s(2, p0, p1, p2)
+spline_line_tangent(s, l0, l1)
+p0 = (0, 0)
+p1 = (1, 2)
+p2 = (2, 0)
+l0 = (0, 1)
+l1 = (2, 1)
+
+# guesses
+p0 roughly (0, 0)
+p1 roughly (1, 2)
+p2 roughly (2, 0)
+l0 roughly (0, 1)
+l1 roughly (2, 1)
+"#;
+    let problem = parse_problem(txt);
+    let outcome = problem
+        .to_constraint_system()
+        .unwrap()
+        .solve_with_config_analysis(Config::default())
+        .unwrap();
+    assert!(outcome.is_satisfied());
 }
 
 #[test]

--- a/ezpz/src/textual.rs
+++ b/ezpz/src/textual.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 pub use executor::ConstraintSystem;
 pub use executor::Outcome;
 pub use executor::OutcomeAnalysis;
-use instruction::Instruction;
+use instruction::{DeclareSpline, Instruction};
 use winnow::Parser;
 
 use crate::datatypes::outputs::Point;
@@ -35,6 +35,7 @@ pub struct Problem {
     inner_points: Vec<Label>,
     inner_circles: Vec<Label>,
     inner_arcs: Vec<Label>,
+    inner_splines: Vec<DeclareSpline>,
     inner_lines: Vec<(Label, Label)>,
     point_guesses: Vec<PointGuess>,
     scalar_guesses: Vec<ScalarGuess>,

--- a/ezpz/src/textual/executor.rs
+++ b/ezpz/src/textual/executor.rs
@@ -892,6 +892,6 @@ q roughly (1, 1)
             .into_iter()
             .find_map(|(id, value)| (id == parameter.id).then_some(value))
             .expect("hidden spline parameter guess should exist");
-        assert_eq!(guess, 0.5);
+        assert!((guess - 0.5).abs() < f64::EPSILON);
     }
 }

--- a/ezpz/src/textual/executor.rs
+++ b/ezpz/src/textual/executor.rs
@@ -13,9 +13,10 @@ use crate::NoAnalysis;
 use crate::SolveOutcome;
 use crate::SolveOutcomeAnalysis;
 use crate::Warning;
-use crate::datatypes;
 use crate::datatypes::AngleKind;
+use crate::datatypes::inputs::DatumCircle;
 use crate::datatypes::inputs::DatumCircularArc;
+use crate::datatypes::inputs::DatumControlPointSpline;
 use crate::datatypes::inputs::DatumDistance;
 use crate::datatypes::inputs::DatumLineSegment;
 use crate::datatypes::inputs::DatumPoint;
@@ -23,6 +24,7 @@ use crate::datatypes::outputs::Arc;
 use crate::datatypes::outputs::{Circle, Component, Point};
 use crate::error::TextualError;
 use crate::textual::Label;
+use crate::textual::geometry_variables::ArcsState;
 use crate::textual::geometry_variables::DoneState;
 use crate::textual::geometry_variables::GeometryVariables;
 use crate::textual::geometry_variables::PointsState;
@@ -31,6 +33,119 @@ use crate::textual::instruction::*;
 
 use super::Instruction;
 use super::Problem;
+
+fn datum_point_for_label(
+    problem: &Problem,
+    initial_guesses: &GeometryVariables<ArcsState>,
+    label: &Label,
+) -> Result<DatumPoint, TextualError> {
+    if let Some(point_id) = problem.inner_points.iter().position(|p| p == &label.0) {
+        let ids = initial_guesses.point_ids(point_id);
+        return Ok(DatumPoint {
+            x_id: ids.x,
+            y_id: ids.y,
+        });
+    }
+    if let Some(circle_id) = problem
+        .inner_circles
+        .iter()
+        .position(|circ| format!("{}.center", circ.0) == label.0.as_str())
+    {
+        let center = initial_guesses.circle_ids(circle_id).center;
+        return Ok(DatumPoint {
+            x_id: center.x,
+            y_id: center.y,
+        });
+    }
+    if let Some(arc_id) = problem
+        .inner_arcs
+        .iter()
+        .position(|arc| format!("{}.center", arc.0) == label.0.as_str())
+    {
+        let center = initial_guesses.arc_ids(arc_id).center;
+        return Ok(center.into());
+    }
+    if let Some(arc_id) = problem
+        .inner_arcs
+        .iter()
+        .position(|arc| format!("{}.a", arc.0) == label.0.as_str())
+    {
+        let start = initial_guesses.arc_ids(arc_id).start;
+        return Ok(start.into());
+    }
+    if let Some(arc_id) = problem
+        .inner_arcs
+        .iter()
+        .position(|arc| format!("{}.b", arc.0) == label.0.as_str())
+    {
+        let end = initial_guesses.arc_ids(arc_id).end;
+        return Ok(end.into());
+    }
+    Err(TextualError::UndefinedPoint {
+        label: label.0.clone(),
+    })
+}
+
+fn datum_distance_for_label(
+    problem: &Problem,
+    initial_guesses: &GeometryVariables<ArcsState>,
+    label: &Label,
+) -> Result<DatumDistance, TextualError> {
+    if let Some(circle_id) = problem
+        .inner_circles
+        .iter()
+        .position(|circ| format!("{}.radius", circ.0) == label.0.as_str())
+    {
+        let ids = initial_guesses.circle_ids(circle_id);
+        return Ok(DatumDistance { id: ids.radius });
+    }
+    Err(TextualError::UndefinedPoint {
+        label: label.0.clone(),
+    })
+}
+
+fn datum_circle_for_label(
+    problem: &Problem,
+    initial_guesses: &GeometryVariables<ArcsState>,
+    label: &Label,
+) -> Result<DatumCircle, TextualError> {
+    let center = datum_point_for_label(
+        problem,
+        initial_guesses,
+        &Label(format!("{}.center", label.0)),
+    )?;
+    let radius = datum_distance_for_label(
+        problem,
+        initial_guesses,
+        &Label(format!("{}.radius", label.0)),
+    )?;
+    Ok(DatumCircle { center, radius })
+}
+
+fn datum_control_point_spline_for_label(
+    problem: &Problem,
+    initial_guesses: &GeometryVariables<ArcsState>,
+    label: &Label,
+) -> Result<DatumControlPointSpline, TextualError> {
+    let Some(spline) = problem
+        .inner_splines
+        .iter()
+        .find(|spline| spline.label == *label)
+    else {
+        return Err(TextualError::UndefinedPoint {
+            label: label.0.clone(),
+        });
+    };
+    let controls = spline
+        .controls
+        .iter()
+        .map(|control| datum_point_for_label(problem, initial_guesses, control))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(DatumControlPointSpline {
+        controls: controls.into_boxed_slice(),
+        degree: spline.degree,
+    })
+}
 
 impl Problem {
     /// Build a [`ConstraintSystem`] which models the system in this problem.
@@ -117,107 +232,59 @@ impl Problem {
         // Good. Now we can define all the constraints, referencing the solver variables that
         // were defined in the previous step.
         let mut constraints = Vec::new();
-        let datum_point_for_label = |label: &Label| -> Result<DatumPoint, TextualError> {
-            // Is the point a single geometric point?
-            if let Some(point_id) = self.inner_points.iter().position(|p| p == &label.0) {
-                let ids = initial_guesses.point_ids(point_id);
-                return Ok(DatumPoint {
-                    x_id: ids.x,
-                    y_id: ids.y,
-                });
-            }
-            // Maybe it's a point in a circle?
-            if let Some(circle_id) = self
-                .inner_circles
-                .iter()
-                .position(|circ| format!("{}.center", circ.0) == label.0.as_str())
-            {
-                let center = initial_guesses.circle_ids(circle_id).center;
-                return Ok(DatumPoint {
-                    x_id: center.x,
-                    y_id: center.y,
-                });
-            }
-            // Maybe it's a point in an arc?
-            // Is it an arc's center?
-            if let Some(arc_id) = self
-                .inner_arcs
-                .iter()
-                .position(|arc| format!("{}.center", arc.0) == label.0.as_str())
-            {
-                let center = initial_guesses.arc_ids(arc_id).center;
-                return Ok(center.into());
-            }
-            // Is it an arc's start point (labeled as `.a` in textual format)?
-            if let Some(arc_id) = self
-                .inner_arcs
-                .iter()
-                .position(|arc| format!("{}.a", arc.0) == label.0.as_str())
-            {
-                let start = initial_guesses.arc_ids(arc_id).start;
-                return Ok(start.into());
-            }
-            // Is it an arc's end point (labeled as `.b` in textual format)?
-            if let Some(arc_id) = self
-                .inner_arcs
-                .iter()
-                .position(|arc| format!("{}.b", arc.0) == label.0.as_str())
-            {
-                let end = initial_guesses.arc_ids(arc_id).end;
-                return Ok(end.into());
-            }
-            // Well, it wasn't any of the geometries we recognize.
-            Err(TextualError::UndefinedPoint {
-                label: label.0.clone(),
-            })
-        };
-        let datum_distance_for_label = |label: &Label| -> Result<DatumDistance, TextualError> {
-            if let Some(circle_id) = self
-                .inner_circles
-                .iter()
-                .position(|circ| format!("{}.radius", circ.0) == label.0.as_str())
-            {
-                let ids = initial_guesses.circle_ids(circle_id);
-                return Ok(DatumDistance { id: ids.radius });
-            }
-            Err(TextualError::UndefinedPoint {
-                label: label.0.clone(),
-            })
-        };
 
         for instr in &self.instructions {
             match instr {
                 Instruction::DeclarePoint(_) => {}
                 Instruction::DeclareCircle(_) => {}
                 Instruction::DeclareArc(_) => {}
+                Instruction::DeclareSpline(_) => {}
                 Instruction::Line(_) => {}
                 Instruction::CircleRadius(CircleRadius { circle, radius }) => {
-                    let circ = &circle.0;
-                    let center_id = datum_point_for_label(&Label(format!("{circ}.center")))?;
-                    let radius_id = datum_distance_for_label(&Label(format!("{circ}.radius")))?;
                     constraints.push(Constraint::CircleRadius(
-                        datatypes::inputs::DatumCircle {
-                            center: center_id,
-                            radius: radius_id,
-                        },
+                        datum_circle_for_label(self, &initial_guesses, circle)?,
                         *radius,
                     ));
                 }
                 Instruction::ArcRadius(ArcRadius { arc_label, radius }) => {
                     let arc_label = &arc_label.0;
                     let circular_arc = DatumCircularArc {
-                        center: datum_point_for_label(&Label(format!("{arc_label}.center")))?,
-                        start: datum_point_for_label(&Label(format!("{arc_label}.a")))?,
-                        end: datum_point_for_label(&Label(format!("{arc_label}.b")))?,
+                        center: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.center")),
+                        )?,
+                        start: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.a")),
+                        )?,
+                        end: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.b")),
+                        )?,
                     };
                     constraints.push(Constraint::ArcRadius(circular_arc, *radius));
                 }
                 Instruction::IsArc(IsArc { arc_label }) => {
                     let arc_label = &arc_label.0;
                     let circular_arc = DatumCircularArc {
-                        center: datum_point_for_label(&Label(format!("{arc_label}.center")))?,
-                        start: datum_point_for_label(&Label(format!("{arc_label}.a")))?,
-                        end: datum_point_for_label(&Label(format!("{arc_label}.b")))?,
+                        center: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.center")),
+                        )?,
+                        start: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.a")),
+                        )?,
+                        end: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.b")),
+                        )?,
                     };
                     constraints.push(Constraint::Arc(circular_arc));
                 }
@@ -228,10 +295,10 @@ impl Problem {
                     distance,
                 }) => {
                     let line = DatumLineSegment {
-                        p0: datum_point_for_label(line_p0)?,
-                        p1: datum_point_for_label(line_p1)?,
+                        p0: datum_point_for_label(self, &initial_guesses, line_p0)?,
+                        p1: datum_point_for_label(self, &initial_guesses, line_p1)?,
                     };
-                    let p = datum_point_for_label(point)?;
+                    let p = datum_point_for_label(self, &initial_guesses, point)?;
                     constraints.push(Constraint::PointLineDistance(p, line, *distance));
                 }
                 Instruction::Tangent(Tangent {
@@ -239,20 +306,48 @@ impl Problem {
                     line_p0,
                     line_p1,
                 }) => {
-                    let circ = &circle.0;
-                    let center_id = datum_point_for_label(&Label(format!("{circ}.center")))?;
-                    let radius_id = datum_distance_for_label(&Label(format!("{circ}.radius")))?;
                     let line = DatumLineSegment {
-                        p0: datum_point_for_label(line_p0)?,
-                        p1: datum_point_for_label(line_p1)?,
+                        p0: datum_point_for_label(self, &initial_guesses, line_p0)?,
+                        p1: datum_point_for_label(self, &initial_guesses, line_p1)?,
                     };
                     constraints.push(Constraint::LineTangentToCircle(
                         line,
-                        datatypes::inputs::DatumCircle {
-                            center: center_id,
-                            radius: radius_id,
-                        },
+                        datum_circle_for_label(self, &initial_guesses, circle)?,
                     ));
+                }
+                Instruction::PointSplineCoincident(PointSplineCoincident { point, spline }) => {
+                    let spline =
+                        datum_control_point_spline_for_label(self, &initial_guesses, spline)?;
+                    let point = datum_point_for_label(self, &initial_guesses, point)?;
+                    let parameter = DatumDistance::new(
+                        initial_guesses.push_hidden_scalar(&mut id_generator, 0.5),
+                    );
+                    constraints.push(Constraint::PointSplineCoincident(spline, point, parameter));
+                }
+                Instruction::SplineLineTangent(SplineLineTangent {
+                    spline,
+                    line_p0,
+                    line_p1,
+                }) => {
+                    let spline =
+                        datum_control_point_spline_for_label(self, &initial_guesses, spline)?;
+                    let line = DatumLineSegment {
+                        p0: datum_point_for_label(self, &initial_guesses, line_p0)?,
+                        p1: datum_point_for_label(self, &initial_guesses, line_p1)?,
+                    };
+                    let parameter = DatumDistance::new(
+                        initial_guesses.push_hidden_scalar(&mut id_generator, 0.5),
+                    );
+                    constraints.push(Constraint::SplineLineTangent(spline, line, parameter));
+                }
+                Instruction::SplineCircleTangent(SplineCircleTangent { spline, circle }) => {
+                    let spline =
+                        datum_control_point_spline_for_label(self, &initial_guesses, spline)?;
+                    let circle = datum_circle_for_label(self, &initial_guesses, circle)?;
+                    let parameter = DatumDistance::new(
+                        initial_guesses.push_hidden_scalar(&mut id_generator, 0.5),
+                    );
+                    constraints.push(Constraint::SplineCircleTangent(spline, circle, parameter));
                 }
                 Instruction::FixPointComponent(FixPointComponent {
                     point,
@@ -317,37 +412,49 @@ impl Problem {
                     }
                 }
                 Instruction::Vertical(Vertical { label }) => {
-                    let p0 = datum_point_for_label(&label.0)?;
-                    let p1 = datum_point_for_label(&label.1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, &label.0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, &label.1)?;
                     constraints.push(Constraint::Vertical(DatumLineSegment { p0, p1 }));
                 }
                 Instruction::PointsCoincident(PointsCoincident { point0, point1 }) => {
-                    let p0 = datum_point_for_label(point0)?;
-                    let p1 = datum_point_for_label(point1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, point0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, point1)?;
                     constraints.push(Constraint::PointsCoincident(p0, p1));
                 }
                 Instruction::PointArcCoincident(PointArcCoincident { point, arc }) => {
-                    let p = datum_point_for_label(point)?;
+                    let p = datum_point_for_label(self, &initial_guesses, point)?;
                     let arc_label = &arc.0;
                     let datum_arc = DatumCircularArc {
-                        center: datum_point_for_label(&Label(format!("{arc_label}.center")))?,
-                        start: datum_point_for_label(&Label(format!("{arc_label}.a")))?,
-                        end: datum_point_for_label(&Label(format!("{arc_label}.b")))?,
+                        center: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.center")),
+                        )?,
+                        start: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.a")),
+                        )?,
+                        end: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.b")),
+                        )?,
                     };
                     constraints.push(Constraint::PointArcCoincident(datum_arc, p));
                 }
                 Instruction::Midpoint(Midpoint { point0, point1, mp }) => {
-                    let p0 = datum_point_for_label(point0)?;
-                    let p1 = datum_point_for_label(point1)?;
-                    let mp = datum_point_for_label(mp)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, point0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, point1)?;
+                    let mp = datum_point_for_label(self, &initial_guesses, mp)?;
                     constraints.push(Constraint::Midpoint(DatumLineSegment { p0, p1 }, mp));
                 }
                 Instruction::Symmetric(Symmetric { p0, p1, line }) => {
-                    let p0 = datum_point_for_label(p0)?;
-                    let p1 = datum_point_for_label(p1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, p0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, p1)?;
                     let line = (
-                        datum_point_for_label(&line.0)?,
-                        datum_point_for_label(&line.1)?,
+                        datum_point_for_label(self, &initial_guesses, &line.0)?,
+                        datum_point_for_label(self, &initial_guesses, &line.1)?,
                     );
                     let line = DatumLineSegment {
                         p0: line.0,
@@ -356,40 +463,40 @@ impl Problem {
                     constraints.push(Constraint::Symmetric(line, p0, p1));
                 }
                 Instruction::Horizontal(Horizontal { label }) => {
-                    let p0 = datum_point_for_label(&label.0)?;
-                    let p1 = datum_point_for_label(&label.1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, &label.0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, &label.1)?;
                     constraints.push(Constraint::Horizontal(DatumLineSegment { p0, p1 }));
                 }
                 Instruction::Distance(Distance { label, distance }) => {
-                    let p0 = datum_point_for_label(&label.0)?;
-                    let p1 = datum_point_for_label(&label.1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, &label.0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, &label.1)?;
                     constraints.push(Constraint::Distance(p0, p1, *distance));
                 }
                 Instruction::Parallel(Parallel { line0, line1 }) => {
-                    let p0 = datum_point_for_label(&line0.0)?;
-                    let p1 = datum_point_for_label(&line0.1)?;
-                    let p2 = datum_point_for_label(&line1.0)?;
-                    let p3 = datum_point_for_label(&line1.1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, &line0.0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, &line0.1)?;
+                    let p2 = datum_point_for_label(self, &initial_guesses, &line1.0)?;
+                    let p3 = datum_point_for_label(self, &initial_guesses, &line1.1)?;
                     constraints.push(Constraint::lines_parallel([
                         DatumLineSegment { p0, p1 },
                         DatumLineSegment { p0: p2, p1: p3 },
                     ]));
                 }
                 Instruction::LinesEqualLength(LinesEqualLength { line0, line1 }) => {
-                    let p0 = datum_point_for_label(&line0.0)?;
-                    let p1 = datum_point_for_label(&line0.1)?;
-                    let p2 = datum_point_for_label(&line1.0)?;
-                    let p3 = datum_point_for_label(&line1.1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, &line0.0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, &line0.1)?;
+                    let p2 = datum_point_for_label(self, &initial_guesses, &line1.0)?;
+                    let p3 = datum_point_for_label(self, &initial_guesses, &line1.1)?;
                     constraints.push(Constraint::LinesEqualLength(
                         DatumLineSegment { p0, p1 },
                         DatumLineSegment { p0: p2, p1: p3 },
                     ));
                 }
                 Instruction::Perpendicular(Perpendicular { line0, line1 }) => {
-                    let p0 = datum_point_for_label(&line0.0)?;
-                    let p1 = datum_point_for_label(&line0.1)?;
-                    let p2 = datum_point_for_label(&line1.0)?;
-                    let p3 = datum_point_for_label(&line1.1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, &line0.0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, &line0.1)?;
+                    let p2 = datum_point_for_label(self, &initial_guesses, &line1.0)?;
+                    let p3 = datum_point_for_label(self, &initial_guesses, &line1.1)?;
                     constraints.push(Constraint::lines_perpendicular([
                         DatumLineSegment { p0, p1 },
                         DatumLineSegment { p0: p2, p1: p3 },
@@ -400,10 +507,10 @@ impl Problem {
                     line1,
                     angle,
                 }) => {
-                    let p0 = datum_point_for_label(&line0.0)?;
-                    let p1 = datum_point_for_label(&line0.1)?;
-                    let p2 = datum_point_for_label(&line1.0)?;
-                    let p3 = datum_point_for_label(&line1.1)?;
+                    let p0 = datum_point_for_label(self, &initial_guesses, &line0.0)?;
+                    let p1 = datum_point_for_label(self, &initial_guesses, &line0.1)?;
+                    let p2 = datum_point_for_label(self, &initial_guesses, &line1.0)?;
+                    let p3 = datum_point_for_label(self, &initial_guesses, &line1.1)?;
                     constraints.push(Constraint::LinesAtAngle(
                         DatumLineSegment { p0, p1 },
                         DatumLineSegment { p0: p2, p1: p3 },
@@ -414,9 +521,21 @@ impl Problem {
                     let arc_label = &arc_length.arc.0;
                     let length = arc_length.distance;
                     let circular_arc = DatumCircularArc {
-                        center: datum_point_for_label(&Label(format!("{arc_label}.center")))?,
-                        start: datum_point_for_label(&Label(format!("{arc_label}.a")))?,
-                        end: datum_point_for_label(&Label(format!("{arc_label}.b")))?,
+                        center: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.center")),
+                        )?,
+                        start: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.a")),
+                        )?,
+                        end: datum_point_for_label(
+                            self,
+                            &initial_guesses,
+                            &Label(format!("{arc_label}.b")),
+                        )?,
                     };
                     constraints.push(Constraint::ArcLength(circular_arc, length));
                 }
@@ -666,6 +785,8 @@ impl OutcomeAnalysis {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::textual::{PointGuess, instruction::FixPointComponent};
 
@@ -675,6 +796,7 @@ mod tests {
             inner_points: Vec::new(),
             inner_circles: Vec::new(),
             inner_arcs: Vec::new(),
+            inner_splines: Vec::new(),
             inner_lines: Vec::new(),
             point_guesses: Vec::new(),
             scalar_guesses: Vec::new(),
@@ -734,5 +856,42 @@ mod tests {
             .err()
             .expect("expected undefined point error");
         assert!(matches!(err, TextualError::UndefinedPoint { label } if label == "missing"));
+    }
+
+    #[test]
+    fn point_spline_coincident_adds_hidden_parameter_guess() {
+        let problem = Problem::from_str(
+            r#"# constraints
+point p0
+point p1
+point p2
+point q
+spline s(2, p0, p1, p2)
+point_spline_coincident(q, s)
+
+# guesses
+p0 roughly (0, 0)
+p1 roughly (1, 2)
+p2 roughly (2, 0)
+q roughly (1, 1)
+"#,
+        )
+        .unwrap();
+
+        let system = problem.to_constraint_system().unwrap();
+        assert_eq!(system.constraints.len(), 1);
+        assert_eq!(system.initial_guesses.len(), 9);
+
+        let Constraint::PointSplineCoincident(_, _, parameter) = system.constraints[0].constraint()
+        else {
+            panic!("expected point-spline coincident constraint");
+        };
+        let guess = system
+            .initial_guesses
+            .variables()
+            .into_iter()
+            .find_map(|(id, value)| (id == parameter.id).then_some(value))
+            .expect("hidden spline parameter guess should exist");
+        assert_eq!(guess, 0.5);
     }
 }

--- a/ezpz/src/textual/geometry_variables.rs
+++ b/ezpz/src/textual/geometry_variables.rs
@@ -176,6 +176,14 @@ impl GeometryVariables<ArcsState> {
     }
 }
 
+impl GeometryVariables<ArcsState> {
+    /// Add an extra hidden scalar variable after all user-visible arcs.
+    pub fn push_hidden_scalar(&mut self, id_generator: &mut IdGenerator, guess: f64) -> Id {
+        self.push_scalar(id_generator, guess);
+        self.variables.last().expect("just pushed hidden scalar").0
+    }
+}
+
 pub struct PointVars {
     pub x: Id,
     pub y: Id,

--- a/ezpz/src/textual/instruction.rs
+++ b/ezpz/src/textual/instruction.rs
@@ -7,6 +7,7 @@ pub(crate) enum Instruction {
     DeclarePoint(DeclarePoint),
     DeclareCircle(DeclareCircle),
     DeclareArc(DeclareArc),
+    DeclareSpline(DeclareSpline),
     FixPointComponent(FixPointComponent),
     Vertical(Vertical),
     Horizontal(Horizontal),
@@ -27,6 +28,9 @@ pub(crate) enum Instruction {
     PointLineDistance(PointLineDistance),
     Line(Line),
     ArcLength(ArcLength),
+    PointSplineCoincident(PointSplineCoincident),
+    SplineLineTangent(SplineLineTangent),
+    SplineCircleTangent(SplineCircleTangent),
 }
 
 #[derive(Debug)]
@@ -156,6 +160,13 @@ pub struct DeclareArc {
     pub label: Label,
 }
 
+#[derive(Debug, Clone)]
+pub struct DeclareSpline {
+    pub label: Label,
+    pub degree: usize,
+    pub controls: Vec<Label>,
+}
+
 #[derive(Debug)]
 pub struct FixPointComponent {
     pub point: Label,
@@ -168,4 +179,23 @@ pub struct FixCenterPointComponent {
     pub object: Label,
     pub center_component: Component,
     pub value: f64,
+}
+
+#[derive(Debug)]
+pub struct PointSplineCoincident {
+    pub point: Label,
+    pub spline: Label,
+}
+
+#[derive(Debug)]
+pub struct SplineLineTangent {
+    pub spline: Label,
+    pub line_p0: Label,
+    pub line_p1: Label,
+}
+
+#[derive(Debug)]
+pub struct SplineCircleTangent {
+    pub spline: Label,
+    pub circle: Label,
 }

--- a/ezpz/src/textual/parser.rs
+++ b/ezpz/src/textual/parser.rs
@@ -4,10 +4,11 @@ use crate::{
     textual::{
         ScalarGuess,
         instruction::{
-            AngleLine, ArcLength, ArcRadius, CircleRadius, DeclareArc, DeclareCircle, Distance,
-            FixCenterPointComponent, IsArc, Line, LinesEqualLength, Midpoint, Parallel,
-            Perpendicular, PointArcCoincident, PointLineDistance, PointsCoincident, Symmetric,
-            Tangent,
+            AngleLine, ArcLength, ArcRadius, CircleRadius, DeclareArc, DeclareCircle,
+            DeclareSpline, Distance, FixCenterPointComponent, IsArc, Line, LinesEqualLength,
+            Midpoint, Parallel, Perpendicular, PointArcCoincident, PointLineDistance,
+            PointSplineCoincident, PointsCoincident, SplineCircleTangent, SplineLineTangent,
+            Symmetric, Tangent,
         },
     },
 };
@@ -32,6 +33,7 @@ pub fn parse_problem(i: &mut &str) -> WResult<Problem> {
     let mut inner_points = Vec::new();
     let mut inner_circles = Vec::new();
     let mut inner_arcs = Vec::new();
+    let mut inner_splines = Vec::new();
     let mut inner_lines = Vec::new();
     for instr in instructions.iter().flatten() {
         if let Instruction::DeclarePoint(dp) = instr {
@@ -42,6 +44,9 @@ pub fn parse_problem(i: &mut &str) -> WResult<Problem> {
         }
         if let Instruction::DeclareArc(dc) = instr {
             inner_arcs.push(dc.label.clone());
+        }
+        if let Instruction::DeclareSpline(ds) = instr {
+            inner_splines.push(ds.clone());
         }
         if let Instruction::Line(line) = instr {
             inner_lines.push((line.p0.clone(), line.p1.clone()));
@@ -69,6 +74,7 @@ pub fn parse_problem(i: &mut &str) -> WResult<Problem> {
         inner_points,
         inner_circles,
         inner_arcs,
+        inner_splines,
         inner_lines,
         point_guesses,
         scalar_guesses,
@@ -152,6 +158,19 @@ pub fn parse_declare_arc(i: &mut &str) -> WResult<DeclareArc> {
         .parse_next(i)
 }
 
+pub fn parse_declare_spline(i: &mut &str) -> WResult<DeclareSpline> {
+    let _ = "spline".parse_next(i)?;
+    ws.parse_next(i)?;
+    let label = parse_label(i)?;
+    ignore_ws(i);
+    let (degree, _, controls) = inside_brackets((parse_usize, commasep, parse_control_labels), i)?;
+    Ok(DeclareSpline {
+        label,
+        degree,
+        controls,
+    })
+}
+
 pub fn parse_horizontal(i: &mut &str) -> WResult<Horizontal> {
     let _ = "horizontal".parse_next(i)?;
     ignore_ws(i);
@@ -171,6 +190,13 @@ pub fn parse_point_arc_coincident(i: &mut &str) -> WResult<PointArcCoincident> {
     ignore_ws(i);
     let [point, arc] = inside_brackets(two_points, i)?;
     Ok(PointArcCoincident { point, arc })
+}
+
+pub fn parse_point_spline_coincident(i: &mut &str) -> WResult<PointSplineCoincident> {
+    let _ = "point_spline_coincident".parse_next(i)?;
+    ignore_ws(i);
+    let (point, _, spline) = inside_brackets((parse_label, commasep, parse_label), i)?;
+    Ok(PointSplineCoincident { point, spline })
 }
 
 pub fn parse_midpoint(i: &mut &str) -> WResult<Midpoint> {
@@ -280,6 +306,27 @@ pub fn parse_tangent(i: &mut &str) -> WResult<Tangent> {
     })
 }
 
+pub fn parse_spline_line_tangent(i: &mut &str) -> WResult<SplineLineTangent> {
+    let _ = "spline_line_tangent".parse_next(i)?;
+    ignore_ws(i);
+    let (spline, _, line_p0, _, line_p1) = inside_brackets(
+        (parse_label, commasep, parse_label, commasep, parse_label),
+        i,
+    )?;
+    Ok(SplineLineTangent {
+        spline,
+        line_p0,
+        line_p1,
+    })
+}
+
+pub fn parse_spline_circle_tangent(i: &mut &str) -> WResult<SplineCircleTangent> {
+    let _ = "spline_circle_tangent".parse_next(i)?;
+    ignore_ws(i);
+    let (spline, _, circle) = inside_brackets((parse_label, commasep, parse_label), i)?;
+    Ok(SplineCircleTangent { spline, circle })
+}
+
 pub fn parse_arc_radius(i: &mut &str) -> WResult<ArcRadius> {
     let _ = "arc_radius".parse_next(i)?;
     ignore_ws(i);
@@ -380,6 +427,10 @@ fn three_labels_num(i: &mut &str) -> WResult<(Label, Label, Label, f64)> {
     Ok((p, lp0, lp1, d))
 }
 
+fn parse_control_labels(i: &mut &str) -> WResult<Vec<Label>> {
+    separated(3.., parse_label, commasep).parse_next(i)
+}
+
 /// Single-element vector
 fn sv<T>(t: T) -> Vec<T> {
     vec![t]
@@ -391,6 +442,7 @@ fn parse_instruction(i: &mut &str) -> WResult<Vec<Instruction>> {
         parse_declare_point.map(Instruction::DeclarePoint).map(sv),
         parse_declare_circle.map(Instruction::DeclareCircle).map(sv),
         parse_declare_arc.map(Instruction::DeclareArc).map(sv),
+        parse_declare_spline.map(Instruction::DeclareSpline).map(sv),
         parse_fix_point_component
             .map(Instruction::FixPointComponent)
             .map(sv),
@@ -402,6 +454,9 @@ fn parse_instruction(i: &mut &str) -> WResult<Vec<Instruction>> {
         parse_coincident.map(Instruction::PointsCoincident).map(sv),
         parse_point_arc_coincident
             .map(Instruction::PointArcCoincident)
+            .map(sv),
+        parse_point_spline_coincident
+            .map(Instruction::PointSplineCoincident)
             .map(sv),
         parse_midpoint.map(Instruction::Midpoint).map(sv),
         parse_symmetric.map(Instruction::Symmetric).map(sv),
@@ -419,6 +474,12 @@ fn parse_other_instructions(i: &mut &str) -> WResult<Vec<Instruction>> {
         parse_angle_line.map(Instruction::AngleLine).map(sv),
         parse_circle_radius.map(Instruction::CircleRadius).map(sv),
         parse_tangent.map(Instruction::Tangent).map(sv),
+        parse_spline_line_tangent
+            .map(Instruction::SplineLineTangent)
+            .map(sv),
+        parse_spline_circle_tangent
+            .map(Instruction::SplineCircleTangent)
+            .map(sv),
         parse_arc_radius.map(Instruction::ArcRadius).map(sv),
         parse_arc_length.map(Instruction::ArcLength).map(sv),
         parse_is_arc.map(Instruction::IsArc).map(sv),
@@ -538,6 +599,12 @@ fn parse_number(i: &mut &str) -> WResult<f64> {
     alt((myfloat, myint)).parse_next(i)
 }
 
+fn parse_usize(i: &mut &str) -> WResult<usize> {
+    digit1
+        .verify_map(|s: &str| s.parse::<usize>().ok())
+        .parse_next(i)
+}
+
 fn parse_number_expr(i: &mut &str) -> WResult<f64> {
     alt((
         parse_number,
@@ -548,6 +615,8 @@ fn parse_number_expr(i: &mut &str) -> WResult<f64> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use crate::tests::assert_nearly_eq;
 
     use super::*;
@@ -557,5 +626,33 @@ mod tests {
         let i = parse_angle(&mut "0deg").unwrap();
         let j = parse_angle(&mut "0rad").unwrap();
         assert_nearly_eq(i.to_degrees(), j.to_degrees());
+    }
+
+    #[test]
+    fn test_parse_spline_problem() {
+        let txt = r#"# constraints
+point p0
+point p1
+point p2
+point q
+spline s(2, p0, p1, p2)
+point_spline_coincident(q, s)
+spline_line_tangent(s, p0, p1)
+spline_circle_tangent(s, c)
+circle c
+
+# guesses
+p0 roughly (0, 0)
+p1 roughly (1, 2)
+p2 roughly (2, 0)
+q roughly (1, 1)
+c.center roughly (1, 0)
+c.radius roughly 1
+"#;
+        let problem = Problem::from_str(txt).unwrap();
+        assert_eq!(problem.inner_splines.len(), 1);
+        assert_eq!(problem.inner_splines[0].label, "s");
+        assert_eq!(problem.inner_splines[0].degree, 2);
+        assert_eq!(problem.inner_splines[0].controls.len(), 3);
     }
 }


### PR DESCRIPTION
<img width="640" height="360" alt="spline11" src="https://github.com/user-attachments/assets/20dbcd1c-0719-4896-a224-934c96a937bb" />

Related to https://github.com/KittyCAD/modeling-app/issues/11103
ZDS PR: https://github.com/KittyCAD/modeling-app/pull/11127
EZPZ PR: https://github.com/KittyCAD/ezpz/pull/247

Please do user test this by using this [preview url](https://modeling-gmxdhn0zz.vercel.dev.zoo.dev/) and a good sample bit of kcl is
```kcl
@settings(experimentalFeatures = allow)

sketch001 = sketch(on = YZ) {
  controlPointSpline1 = controlPointSpline(points = [
    [var -3.43mm, var -0.99mm],
    [var -4.8mm, var 0.67mm],
    [var -4.39mm, var 3.42mm],
    [var 4.04mm, var 2.88mm],
    [var 2.42mm, var 6.3mm]
  ])
  arc2 = arc(start = [var 2.53mm, var 7.99mm], end = [var 2.42mm, var 6.3mm], center = [var 3.99mm, var 7.04mm])
  arc1 = arc(start = [var -5.77mm, var 2.71mm], end = [var -2.31mm, var 4.26mm], center = [var -4.27mm, var 4mm])
  circle1 = circle(start = [var -1.8mm, var 6.85mm], center = [var -0.29mm, var 5.21mm])
  tangent([controlPointSpline1, arc1])
  tangent([controlPointSpline1, circle1])
  coincident([
    controlPointSpline1.controls[4],
    arc2.end
  ])
  tangent([controlPointSpline1, arc2])
  line1 = line(start = [var 2.53mm, var 7.99mm], end = [var 5.84mm, var 7.32mm])
  coincident([line1.start, arc2.start])
  line2 = line(start = [var 5.84mm, var 7.32mm], end = [var 5.5mm, var -2.19mm])
  coincident([line1.end, line2.start])
  line3 = line(start = [var 5.5mm, var -2.19mm], end = [var -3.43mm, var -0.99mm])
  coincident([line2.end, line3.start])
  coincident([
    line3.end,
    controlPointSpline1.controls[0]
  ])
}

```

This PR adds control-point spline support to `ezpz` at the solver and textual-debugging layers.

It introduces a new `DatumControlPointSpline` input type and three new constraints:

- `PointSplineCoincident`
- `SplineLineTangent`
- `SplineCircleTangent`

These constraints are fully wired through residual evaluation, Jacobian generation, dependent/associated variable reporting, and solver tests.

This PR also adds textual format support so spline problems can be debugged and reproduced outside the product stack. The textual layer now supports:

- spline declaration, for example `spline s(2, p0, p1, p2)`
- point-on-spline coincidence
- spline-line tangency
- spline-circle tangency

The main design detail to call out is the extra interval value used by the new spline constraints. Each of these constraints needs to refer to a specific point on the spline, but that point is not known ahead of time. For example:

- a point-on-spline constraint must solve for where along the spline the point lies
- a tangent-to-line constraint must solve for where along the spline the tangent occurs
- a tangent-to-circle constraint must solve for where along the spline the tangency occurs

To model that, the solver uses an additional scalar variable, represented as `DatumDistance`, as the spline parameter. This lets the solver move the coincidence or tangency location along the spline while also solving the geometric variables for the rest of the sketch. Without this interval value, the spline constraints would only be usable if the contact location were fixed in advance, which would make them much less useful.

The textual executor keeps that parameter internal. Users declare spline constraints in the text format without providing the interval value themselves, and the executor creates the hidden scalar with a default initial guess. That keeps the text format usable for debugging while still matching the solver model required by the new constraints.

Tests cover:

- direct solver tests for spline coincidence and tangency
- endpoint tangency behavior
- textual parser support for spline declarations and spline constraints
- textual executor behavior, including creation of the hidden spline parameter
- end-to-end textual solve coverage for spline constraints