### PR TITLE
Specify side for circle-circle tangency

### DIFF
--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -38,7 +38,7 @@ pub enum Constraint {
     /// These two circles should be tangent.
     /// This could include internal tangency (where one circle is inside the other),
     /// or external (where they're adjacent).
-    CircleTangentToCircle(DatumCircle, DatumCircle),
+    CircleTangentToCircle(DatumCircle, DatumCircle, CircleSide),
     /// These two points should be a given distance apart.
     Distance(DatumPoint, DatumPoint, f64),
     /// These two points should have distance equal to the given variable.
@@ -111,6 +111,19 @@ pub enum LineSide {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
+/// Which side of a circle a constraint refers to.
+pub enum CircleSide {
+    /// Infer the side from the initial conditions before solving.
+    Undefined,
+    /// Exterior of a circle
+    Exterior,
+    /// Interior of a circle
+    Interior,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PointArcCoincidentPart {
     Interior,
     Start,
@@ -146,6 +159,30 @@ impl Constraint {
                     LineSide::Right
                 };
             }
+            Constraint::CircleTangentToCircle(circle_a, circle_b, side)
+                if *side == CircleSide::Undefined =>
+            {
+                let a_c = V::new(
+                    initial_values[circle_a.center.id_x() as usize],
+                    initial_values[circle_a.center.id_y() as usize],
+                );
+                let a_r = initial_values[circle_a.radius.id as usize];
+
+                let b_c = V::new(
+                    initial_values[circle_b.center.id_x() as usize],
+                    initial_values[circle_b.center.id_y() as usize],
+                );
+                let b_r = initial_values[circle_b.radius.id as usize];
+
+                let dist = (a_c - b_c).magnitude();
+                let r_int = ((a_r - b_r).abs() - dist).abs();
+                let r_ext = (a_r + b_r - dist).abs();
+                *side = if r_int < r_ext {
+                    CircleSide::Interior
+                } else {
+                    CircleSide::Exterior
+                };
+            }
             _ => {}
         }
     }
@@ -169,7 +206,7 @@ impl Constraint {
                 out.extend(line.all_variables());
                 out.extend(circle.all_variables());
             }
-            Constraint::CircleTangentToCircle(circle0, circle1) => {
+            Constraint::CircleTangentToCircle(circle0, circle1, _side) => {
                 out.extend(circle0.all_variables());
                 out.extend(circle1.all_variables());
             }
@@ -254,7 +291,7 @@ impl Constraint {
                 out.extend(line.all_variables());
                 out.extend(circle.all_variables());
             }
-            Constraint::CircleTangentToCircle(circle0, circle1) => {
+            Constraint::CircleTangentToCircle(circle0, circle1, _side) => {
                 out.extend(circle0.all_variables());
                 out.extend(circle1.all_variables());
             }
@@ -329,7 +366,7 @@ impl Constraint {
                 row0.extend(line.all_variables());
                 row0.extend(circle.all_variables());
             }
-            Constraint::CircleTangentToCircle(circle0, circle1) => {
+            Constraint::CircleTangentToCircle(circle0, circle1, _side) => {
                 row0.extend(circle0.all_variables());
                 row0.extend(circle1.all_variables());
             }
@@ -482,31 +519,25 @@ impl Constraint {
                 // NOTE: Taking abs of radius here since the var could technically be negative
                 *residual0 = cen_dist - radius.abs();
             }
-            Constraint::CircleTangentToCircle(circle_a, circle_b) => {
-                // Get current state of the entities.
-                let ax = current_assignments[layout.index_of(circle_a.center.id_x())];
-                let ay = current_assignments[layout.index_of(circle_a.center.id_y())];
-                let ar = current_assignments[layout.index_of(circle_a.radius.id)];
-                let bx = current_assignments[layout.index_of(circle_b.center.id_x())];
-                let by = current_assignments[layout.index_of(circle_b.center.id_y())];
-                let br = current_assignments[layout.index_of(circle_b.radius.id)];
+            Constraint::CircleTangentToCircle(circle_a, circle_b, side) => {
+                let a_c = V::new(
+                    current_assignments[layout.index_of(circle_a.center.id_x())],
+                    current_assignments[layout.index_of(circle_a.center.id_y())],
+                );
+                let a_r = current_assignments[layout.index_of(circle_a.radius.id)];
 
-                // Evaluate residuals for both internal and external tangency
-                // See https://github.com/KittyCAD/ezpz-sympy/pull/1
-                let residual_internal =
-                    -((ax - bx).powi(2) + (ay - by).powi(2)).sqrt() + (ar - br).abs();
-                let residual_external = ar + br - ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt();
-                let is_internal =
-                    (((ax - bx).powi(2) + (ay - by).powi(2)).sqrt() - (ar - br).abs()).abs()
-                        < (ar + br - ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt()).abs();
+                let b_c = V::new(
+                    current_assignments[layout.index_of(circle_b.center.id_x())],
+                    current_assignments[layout.index_of(circle_b.center.id_y())],
+                );
+                let b_r = current_assignments[layout.index_of(circle_b.radius.id)];
 
-                // Use whichever kind of tangency has a smaller residual.
-                let smaller_residual = if is_internal {
-                    residual_internal
+                let dist = (a_c - b_c).magnitude();
+                *residual0 = if *side == CircleSide::Interior {
+                    (a_r - b_r).abs() - dist
                 } else {
-                    residual_external
+                    a_r + b_r - dist
                 };
-                *residual0 = smaller_residual;
             }
             Constraint::Distance(p0, p1, expected_distance) => {
                 let p0_x = current_assignments[layout.index_of(p0.id_x())];
@@ -1003,82 +1034,60 @@ impl Constraint {
                 ];
                 row0.extend(coeffs.as_slice());
             }
-            Constraint::CircleTangentToCircle(circle_a, circle_b) => {
-                // Get current state of the entities.
-                let ax_id = circle_a.center.id_x();
-                let ay_id = circle_a.center.id_y();
-                let ar_id = circle_a.radius.id;
-                let bx_id = circle_b.center.id_x();
-                let by_id = circle_b.center.id_y();
-                let br_id = circle_b.radius.id;
-                let ax = current_assignments[layout.index_of(ax_id)];
-                let ay = current_assignments[layout.index_of(ay_id)];
-                let ar = current_assignments[layout.index_of(ar_id)];
-                let bx = current_assignments[layout.index_of(bx_id)];
-                let by = current_assignments[layout.index_of(by_id)];
-                let br = current_assignments[layout.index_of(br_id)];
+            Constraint::CircleTangentToCircle(circle_a, circle_b, side) => {
+                let a_c = V::new(
+                    current_assignments[layout.index_of(circle_a.center.id_x())],
+                    current_assignments[layout.index_of(circle_a.center.id_y())],
+                );
+                let a_r = current_assignments[layout.index_of(circle_a.radius.id)];
 
-                // Is the current state of affairs closer to internal or external tangency?
-                // We should steer the system towards whichever is closer.
-                let is_internal =
-                    (((ax - bx).powi(2) + (ay - by).powi(2)).sqrt() - (ar - br).abs()).abs()
-                        < (ar + br - ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt()).abs();
+                let b_c = V::new(
+                    current_assignments[layout.index_of(circle_b.center.id_x())],
+                    current_assignments[layout.index_of(circle_b.center.id_y())],
+                );
+                let b_r = current_assignments[layout.index_of(circle_b.radius.id)];
 
-                // Evaluate residuals for both internal and external tangency
-                // See https://github.com/KittyCAD/ezpz-sympy/pull/1
-                let pd_ax = (-ax + bx) * ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt().recip();
-                let pd_ay = (-ay + by) * ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt().recip();
-                let pd_bx = -(-ax + bx) * ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt().recip();
-                let pd_by = -(-ay + by) * ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt().recip();
-                // The partial derivative of the radius depends on whether we're steering towards
-                // internal/external tangency. Because the internal tangency residual has an
-                // absolute value, we don't differentiate it directly, we just check whether
-                // the sign is positive or negative (i.e. which radius is larger) and differentiate
-                // that specific equation for that specific case.
-                let pd_ar_internal_ra_greater = 1.0;
-                let pd_br_internal_ra_greater = -1.0;
-                let pd_ar_internal_rb_greater = -1.0;
-                let pd_br_internal_rb_greater = 1.0;
-                let pd_ar_external = 1.0;
-                let pd_br_external = 1.0;
-                let (pd_ar, pd_br) = if is_internal {
-                    if ar > br {
-                        (pd_ar_internal_ra_greater, pd_br_internal_ra_greater)
-                    } else {
-                        (pd_ar_internal_rb_greater, pd_br_internal_rb_greater)
-                    }
+                let d = b_c - a_c;
+                let inv_dist = d.magnitude().recip();
+
+                let dr_dax = d.x * inv_dist;
+                let dr_day = d.y * inv_dist;
+                let dr_dbx = -dr_dax;
+                let dr_dby = -dr_day;
+
+                let (dr_dar, dr_dbr) = if *side == CircleSide::Interior {
+                    if a_r > b_r { (1.0, -1.0) } else { (-1.0, 1.0) }
                 } else {
-                    (pd_ar_external, pd_br_external)
+                    (1.0, 1.0)
                 };
 
-                // Done!
-                let pds = [
+                let coeffs = [
                     JacobianVar {
-                        id: ax_id,
-                        partial_derivative: pd_ax,
+                        id: circle_a.center.id_x(),
+                        partial_derivative: dr_dax,
                     },
                     JacobianVar {
-                        id: ay_id,
-                        partial_derivative: pd_ay,
+                        id: circle_a.center.id_y(),
+                        partial_derivative: dr_day,
                     },
                     JacobianVar {
-                        id: ar_id,
-                        partial_derivative: pd_ar,
+                        id: circle_a.radius.id,
+                        partial_derivative: dr_dar,
                     },
                     JacobianVar {
-                        id: bx_id,
-                        partial_derivative: pd_bx,
+                        id: circle_b.center.id_x(),
+                        partial_derivative: dr_dbx,
                     },
                     JacobianVar {
-                        id: by_id,
-                        partial_derivative: pd_by,
+                        id: circle_b.center.id_y(),
+                        partial_derivative: dr_dby,
                     },
                     JacobianVar {
-                        id: br_id,
-                        partial_derivative: pd_br,
+                        id: circle_a.radius.id,
+                        partial_derivative: dr_dbr,
                     },
                 ];
-                row0.extend(pds.as_slice());
+                row0.extend(coeffs.as_slice());
             }
             Constraint::Distance(p0, p1, _expected_distance) => {
                 // Residual: R = sqrt((x1-x2)**2 + (y1-y2)**2) - d

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -524,13 +524,13 @@ impl Constraint {
                     current_assignments[layout.index_of(circle_a.center.id_x())],
                     current_assignments[layout.index_of(circle_a.center.id_y())],
                 );
-                let a_r = current_assignments[layout.index_of(circle_a.radius.id)];
+                let a_r = current_assignments[layout.index_of(circle_a.radius.id)].abs();
 
                 let b_c = V::new(
                     current_assignments[layout.index_of(circle_b.center.id_x())],
                     current_assignments[layout.index_of(circle_b.center.id_y())],
                 );
-                let b_r = current_assignments[layout.index_of(circle_b.radius.id)];
+                let b_r = current_assignments[layout.index_of(circle_b.radius.id)].abs();
 
                 let dist = (a_c - b_c).magnitude();
                 *residual0 = if *side == CircleSide::Interior {
@@ -1048,12 +1048,19 @@ impl Constraint {
                 let b_r = current_assignments[layout.index_of(circle_b.radius.id)];
 
                 let d = b_c - a_c;
-                let d_u = d * d.magnitude().recip();
+                let mag_d = d.magnitude();
 
-                let dr_dax = d_u.x;
-                let dr_day = d_u.y;
-                let dr_dbx = -d_u.x;
-                let dr_dby = -d_u.y;
+                if mag_d <= EPSILON {
+                    *degenerate = true;
+                    return;
+                }
+
+                let u_d = d * mag_d.recip();
+
+                let dr_dax = u_d.x;
+                let dr_day = u_d.y;
+                let dr_dbx = -u_d.x;
+                let dr_dby = -u_d.y;
 
                 let (dr_dar, dr_dbr) = if *side == CircleSide::Interior {
                     if a_r > b_r { (1.0, -1.0) } else { (-1.0, 1.0) }

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -1048,12 +1048,12 @@ impl Constraint {
                 let b_r = current_assignments[layout.index_of(circle_b.radius.id)];
 
                 let d = b_c - a_c;
-                let inv_dist = d.magnitude().recip();
+                let d_u = d * d.magnitude().recip();
 
-                let dr_dax = d.x * inv_dist;
-                let dr_day = d.y * inv_dist;
-                let dr_dbx = -dr_dax;
-                let dr_dby = -dr_day;
+                let dr_dax = d_u.x;
+                let dr_day = d_u.y;
+                let dr_dbx = -d_u.x;
+                let dr_dby = -d_u.y;
 
                 let (dr_dar, dr_dbr) = if *side == CircleSide::Interior {
                     if a_r > b_r { (1.0, -1.0) } else { (-1.0, 1.0) }
@@ -1083,7 +1083,7 @@ impl Constraint {
                         partial_derivative: dr_dby,
                     },
                     JacobianVar {
-                        id: circle_a.radius.id,
+                        id: circle_b.radius.id,
                         partial_derivative: dr_dbr,
                     },
                 ];

--- a/ezpz/src/lib.rs
+++ b/ezpz/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::analysis::FreedomAnalysis;
 use crate::analysis::{Analysis, NoAnalysis, SolveOutcomeAnalysis};
 pub use crate::constraint_request::ConstraintRequest;
 use crate::constraints::ConstraintEntry;
-pub use crate::constraints::{Constraint, LineSide, CircleSide};
+pub use crate::constraints::{CircleSide, Constraint, LineSide};
 pub use crate::error::*;
 pub use crate::solver::Config;
 // Only public for now so that I can benchmark it.

--- a/ezpz/src/lib.rs
+++ b/ezpz/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::analysis::FreedomAnalysis;
 use crate::analysis::{Analysis, NoAnalysis, SolveOutcomeAnalysis};
 pub use crate::constraint_request::ConstraintRequest;
 use crate::constraints::ConstraintEntry;
-pub use crate::constraints::{Constraint, LineSide};
+pub use crate::constraints::{Constraint, LineSide, CircleSide};
 pub use crate::error::*;
 pub use crate::solver::Config;
 // Only public for now so that I can benchmark it.

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -2,7 +2,7 @@ use std::{f64::consts::PI, str::FromStr};
 
 use super::*;
 use crate::{
-    LineSide,
+    CircleSide, LineSide,
     datatypes::{
         Angle, AngleKind,
         inputs::{DatumCircle, DatumCircularArc, DatumDistance, DatumLineSegment, DatumPoint},
@@ -453,6 +453,80 @@ fn line_tangent_right_inferred() {
     let solved_circle = solved.final_value_circle(&circle);
     assert_nearly_eq(solved_circle.center.y, 1.5);
     assert_nearly_eq(solved_circle.radius, 1.5);
+}
+
+#[test]
+fn circle_tangent_external_inferred() {
+    let mut ids = IdGenerator::default();
+    let circle_a = DatumCircle {
+        center: DatumPoint::new(&mut ids),
+        radius: DatumDistance::new(ids.next_id()),
+    };
+    let circle_b = DatumCircle {
+        center: DatumPoint::new(&mut ids),
+        radius: DatumDistance::new(ids.next_id()),
+    };
+
+    let initial_guesses = vec![
+        (circle_a.center.id_x(), 0.0),
+        (circle_a.center.id_y(), 0.0),
+        (circle_a.radius.id, 2.0),
+        (circle_b.center.id_x(), 4.0),
+        (circle_b.center.id_y(), 0.0),
+        (circle_b.radius.id, 3.0),
+    ];
+    let constraints = [
+        ConstraintRequest::highest_priority(Constraint::Fixed(circle_a.radius.id, 2.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(circle_b.radius.id, 3.0)),
+        ConstraintRequest::highest_priority(Constraint::CircleTangentToCircle(
+            circle_a,
+            circle_b,
+            CircleSide::Undefined,
+        )),
+    ];
+
+    let outcome = solve(&constraints, initial_guesses, Config::default()).unwrap();
+    assert!(outcome.is_satisfied());
+    let center_a = outcome.final_value_point(&circle_a.center);
+    let center_b = outcome.final_value_point(&circle_b.center);
+    assert_nearly_eq(center_a.euclidean_distance(center_b), 5.0);
+}
+
+#[test]
+fn circle_tangent_internal_inferred() {
+    let mut ids = IdGenerator::default();
+    let circle_a = DatumCircle {
+        center: DatumPoint::new(&mut ids),
+        radius: DatumDistance::new(ids.next_id()),
+    };
+    let circle_b = DatumCircle {
+        center: DatumPoint::new(&mut ids),
+        radius: DatumDistance::new(ids.next_id()),
+    };
+
+    let initial_guesses = vec![
+        (circle_a.center.id_x(), 0.0),
+        (circle_a.center.id_y(), 0.0),
+        (circle_a.radius.id, 5.0),
+        (circle_b.center.id_x(), 1.0),
+        (circle_b.center.id_y(), 0.0),
+        (circle_b.radius.id, 2.0),
+    ];
+    let constraints = [
+        ConstraintRequest::highest_priority(Constraint::Fixed(circle_a.radius.id, 5.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(circle_b.radius.id, 2.0)),
+        ConstraintRequest::highest_priority(Constraint::CircleTangentToCircle(
+            circle_a,
+            circle_b,
+            CircleSide::Undefined,
+        )),
+    ];
+
+    let outcome = solve(&constraints, initial_guesses, Config::default()).unwrap();
+    assert!(outcome.is_satisfied());
+    let center_a = outcome.final_value_point(&circle_a.center);
+    let center_b = outcome.final_value_point(&circle_b.center);
+    assert_nearly_eq(center_a.euclidean_distance(center_b), 3.0);
 }
 
 #[test]

--- a/ezpz/src/tests/proptests.rs
+++ b/ezpz/src/tests/proptests.rs
@@ -4,7 +4,7 @@ use std::f64::consts::PI;
 use proptest::prelude::*;
 
 use crate::{
-    Config, Constraint, ConstraintRequest, EPSILON, Id, IdGenerator, LineSide,
+    Config, Constraint, ConstraintRequest, EPSILON, Id, IdGenerator, LineSide, CircleSide,
     constraints::JacobianVar,
     datatypes::inputs::{
         DatumCircle, DatumCircularArc, DatumDistance, DatumLineSegment, DatumPoint,
@@ -84,12 +84,17 @@ fn arb_line_side() -> BoxedStrategy<LineSide> {
     prop_oneof![Just(LineSide::Left), Just(LineSide::Right)].boxed()
 }
 
+fn arb_circle_side() -> BoxedStrategy<CircleSide> {
+    prop_oneof![Just(CircleSide::Exterior), Just(CircleSide::Interior)].boxed()
+}
+
 fn arb_constraint() -> BoxedStrategy<Constraint> {
     prop_oneof![
         (arb_line(), arb_circle(), arb_line_side())
             .prop_map(|(line, circle, side)| Constraint::LineTangentToCircle(line, circle, side)),
-        (arb_circle(), arb_circle())
-            .prop_map(|(circle0, circle1)| Constraint::CircleTangentToCircle(circle0, circle1)),
+        (arb_circle(), arb_circle(), arb_circle_side()).prop_map(|(circle0, circle1, side)| {
+            Constraint::CircleTangentToCircle(circle0, circle1, side)
+        }),
         (arb_point(), arb_point(), arb_scalar())
             .prop_map(|(p0, p1, dist)| Constraint::Distance(p0, p1, dist)),
         (arb_point(), arb_point(), arb_distance())
@@ -896,7 +901,15 @@ fn test_circle_circle_tangent(
         ConstraintRequest::highest_priority(Constraint::Fixed(circle_a.radius.id, ar)),
         ConstraintRequest::highest_priority(Constraint::Fixed(circle_b.center.id_y(), by)),
         ConstraintRequest::highest_priority(Constraint::Fixed(circle_b.radius.id, br)),
-        ConstraintRequest::highest_priority(Constraint::CircleTangentToCircle(circle_a, circle_b)),
+        ConstraintRequest::highest_priority(Constraint::CircleTangentToCircle(
+            circle_a,
+            circle_b,
+            if is_internal {
+                CircleSide::Interior
+            } else {
+                CircleSide::Exterior
+            },
+        )),
     ];
 
     let outcome = solve(&requests, initial_guesses, Config::default())


### PR DESCRIPTION
Updates `CircleTangentToCircle` to avoid jumping between the two possible solutions (internal and external) within a solve. Similar to #248, the constraint now carries an enum which determines the type of tangency that's enforced throughout the solve. If undefined, this is inferred from initial conditions.

Note that this won't _completely_ solve stability issues flagged in [this thread](https://kittycadworkspace.slack.com/archives/C09CJ6XPY1Y/p1775813378159889) as it only ensures a consistent side is used within a single solve. The key will be using a consistent side across multiple solves which will require some additional changes at the app level.

Corresponding modeling app PR: https://github.com/KittyCAD/modeling-app/pull/11173
