### PR TITLE
Add `PointsAtAngle` constraint

### DIFF
--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -85,6 +85,8 @@ pub enum Constraint {
     ArcLength(DatumCircularArc, f64),
     /// The arc should span this angle.
     ArcAngle(DatumCircularArc, Angle),
+    /// The oriented angle from (p1 - p0) to (p2 - p0) should equal the given angle.
+    PointsAtAngle(DatumPoint, DatumPoint, DatumPoint, AngleKind),
 }
 
 /// Describes one value in one row of the Jacobian matrix.
@@ -267,6 +269,11 @@ impl Constraint {
             }
             Constraint::ArcLength(circular_arc, _dist) => out.extend(circular_arc.all_variables()),
             Constraint::ArcAngle(circular_arc, _angle) => out.extend(circular_arc.all_variables()),
+            Constraint::PointsAtAngle(p0, p1, p2, _angle) => {
+                out.extend(p0.all_variables());
+                out.extend(p1.all_variables());
+                out.extend(p2.all_variables());
+            }
         }
     }
 
@@ -356,6 +363,11 @@ impl Constraint {
             }
             Constraint::ArcLength(circular_arc, _dist) => out.extend(circular_arc.all_variables()),
             Constraint::ArcAngle(circular_arc, _angle) => out.extend(circular_arc.all_variables()),
+            Constraint::PointsAtAngle(p0, p1, p2, _angle) => {
+                out.extend(p0.all_variables());
+                out.extend(p1.all_variables());
+                out.extend(p2.all_variables());
+            }
         }
     }
 
@@ -464,6 +476,14 @@ impl Constraint {
                 AngleKind::Other(*angle),
             )
             .nonzeroes(row0, row1, _row2),
+            Constraint::PointsAtAngle(p0, p1, p2, _angle) => {
+                row0.extend(p0.all_variables());
+                row0.extend(p1.all_variables());
+                row0.extend(p2.all_variables());
+                row1.extend(p0.all_variables());
+                row1.extend(p1.all_variables());
+                row1.extend(p2.all_variables());
+            }
         }
     }
 
@@ -897,6 +917,41 @@ impl Constraint {
                 _residual2,
                 degenerate,
             ),
+            Constraint::PointsAtAngle(p0, p1, p2, expected_angle) => {
+                let p0v = V::new(
+                    current_assignments[layout.index_of(p0.id_x())],
+                    current_assignments[layout.index_of(p0.id_y())],
+                );
+                let p1v = V::new(
+                    current_assignments[layout.index_of(p1.id_x())],
+                    current_assignments[layout.index_of(p1.id_y())],
+                );
+                let p2v = V::new(
+                    current_assignments[layout.index_of(p2.id_x())],
+                    current_assignments[layout.index_of(p2.id_y())],
+                );
+
+                let u = p1v - p0v;
+                let v = p2v - p0v;
+                let len_u = u.magnitude();
+                let len_v = v.magnitude();
+
+                if len_u <= EPSILON || len_v <= EPSILON {
+                    *degenerate = true;
+                    return;
+                }
+
+                let rot = rotation_for_angle_kind(*expected_angle);
+                let u_hat = u * (1.0 / len_u);
+                let v_hat = v * (1.0 / len_v);
+                let rot_u_hat = rot.apply(u_hat);
+                let scale = (len_u + len_v) * 0.5;
+                let res = v_hat - rot_u_hat;
+
+                // Residual: r = (|u| + |v|) / 2 * (v_hat - R * u_hat)
+                *residual0 = scale * res.x;
+                *residual1 = scale * res.y;
+            }
         }
     }
 
@@ -939,6 +994,7 @@ impl Constraint {
                 AngleKind::Other(*angle),
             )
             .residual_dim(),
+            Constraint::PointsAtAngle(..) => 2,
         }
     }
 
@@ -2138,6 +2194,111 @@ impl Constraint {
                 AngleKind::Other(*angle),
             )
             .jacobian_rows(layout, current_assignments, row0, row1, _row2, degenerate),
+            Constraint::PointsAtAngle(p0, p1, p2, expected_angle) => {
+                let p0v = V::new(
+                    current_assignments[layout.index_of(p0.id_x())],
+                    current_assignments[layout.index_of(p0.id_y())],
+                );
+                let p1v = V::new(
+                    current_assignments[layout.index_of(p1.id_x())],
+                    current_assignments[layout.index_of(p1.id_y())],
+                );
+                let p2v = V::new(
+                    current_assignments[layout.index_of(p2.id_x())],
+                    current_assignments[layout.index_of(p2.id_y())],
+                );
+
+                let u = p1v - p0v;
+                let v = p2v - p0v;
+                let len_u = u.magnitude();
+                let len_v = v.magnitude();
+
+                if len_u <= EPSILON || len_v <= EPSILON {
+                    *degenerate = true;
+                    return;
+                }
+
+                let inv_len_u = 1.0 / len_u;
+                let inv_len_v = 1.0 / len_v;
+                let rot = rotation_for_angle_kind(*expected_angle);
+                let u_hat = u * inv_len_u;
+                let v_hat = v * inv_len_v;
+                let rot_u_hat = rot.apply(u_hat);
+                let scale = (len_u + len_v) * 0.5;
+                let res = v_hat - rot_u_hat;
+
+                // Columns of R: R*e1 = (ca, sa), R*e2 = (-sa, ca)
+                let rot_e1 = rot.apply(V::new(1.0, 0.0));
+                let rot_e2 = rot.apply(V::new(0.0, 1.0));
+
+                // ∂r/∂u
+                let dr_du0 = res * (u_hat.x * 0.5)
+                    + (rot_u_hat * u_hat.x - rot_e1) * (scale * inv_len_u);
+                let dr_du1 = res * (u_hat.y * 0.5)
+                    + (rot_u_hat * u_hat.y - rot_e2) * (scale * inv_len_u);
+
+                // ∂r/∂v
+                let dr_dv0 = res * (v_hat.x * 0.5)
+                    + (V::new(1.0, 0.0) - v_hat * v_hat.x) * (scale * inv_len_v);
+                let dr_dv1 = res * (v_hat.y * 0.5)
+                    + (V::new(0.0, 1.0) - v_hat * v_hat.y) * (scale * inv_len_v);
+
+                // ∂r/∂p0 = -(∂r/∂u + ∂r/∂v)
+                // ∂r/∂p1 = ∂r/∂u
+                // ∂r/∂p2 = ∂r/∂v
+                row0.extend([
+                    JacobianVar {
+                        id: p0.id_x(),
+                        partial_derivative: -(dr_du0.x + dr_dv0.x),
+                    },
+                    JacobianVar {
+                        id: p0.id_y(),
+                        partial_derivative: -(dr_du1.x + dr_dv1.x),
+                    },
+                    JacobianVar {
+                        id: p1.id_x(),
+                        partial_derivative: dr_du0.x,
+                    },
+                    JacobianVar {
+                        id: p1.id_y(),
+                        partial_derivative: dr_du1.x,
+                    },
+                    JacobianVar {
+                        id: p2.id_x(),
+                        partial_derivative: dr_dv0.x,
+                    },
+                    JacobianVar {
+                        id: p2.id_y(),
+                        partial_derivative: dr_dv1.x,
+                    },
+                ]);
+                row1.extend([
+                    JacobianVar {
+                        id: p0.id_x(),
+                        partial_derivative: -(dr_du0.y + dr_dv0.y),
+                    },
+                    JacobianVar {
+                        id: p0.id_y(),
+                        partial_derivative: -(dr_du1.y + dr_dv1.y),
+                    },
+                    JacobianVar {
+                        id: p1.id_x(),
+                        partial_derivative: dr_du0.y,
+                    },
+                    JacobianVar {
+                        id: p1.id_y(),
+                        partial_derivative: dr_du1.y,
+                    },
+                    JacobianVar {
+                        id: p2.id_x(),
+                        partial_derivative: dr_dv0.y,
+                    },
+                    JacobianVar {
+                        id: p2.id_y(),
+                        partial_derivative: dr_dv1.y,
+                    },
+                ]);
+            }
         }
     }
 
@@ -2173,6 +2334,7 @@ impl Constraint {
             Constraint::PointArcCoincident(..) => "PointArcCoincident",
             Constraint::ArcLength(..) => "ArcLength",
             Constraint::ArcAngle(..) => "ArcAngle",
+            Constraint::PointsAtAngle(..) => "PointsAtAngle",
         }
     }
 }

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -2232,10 +2232,10 @@ impl Constraint {
                 let rot_e2 = rot.apply(V::new(0.0, 1.0));
 
                 // ∂r/∂u
-                let dr_du0 = res * (u_hat.x * 0.5)
-                    + (rot_u_hat * u_hat.x - rot_e1) * (scale * inv_len_u);
-                let dr_du1 = res * (u_hat.y * 0.5)
-                    + (rot_u_hat * u_hat.y - rot_e2) * (scale * inv_len_u);
+                let dr_du0 =
+                    res * (u_hat.x * 0.5) + (rot_u_hat * u_hat.x - rot_e1) * (scale * inv_len_u);
+                let dr_du1 =
+                    res * (u_hat.y * 0.5) + (rot_u_hat * u_hat.y - rot_e2) * (scale * inv_len_u);
 
                 // ∂r/∂v
                 let dr_dv0 = res * (v_hat.x * 0.5)

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -1735,6 +1735,32 @@ fn points_at_angle_already_satisfied() {
 }
 
 #[test]
+fn points_at_angle_degenerate() {
+    let vertex = DatumPoint { x_id: 0, y_id: 1 };
+    let p1 = DatumPoint { x_id: 2, y_id: 3 };
+    let p2 = DatumPoint { x_id: 4, y_id: 5 };
+
+    let constraints = [ConstraintRequest::highest_priority(
+        Constraint::PointsAtAngle(vertex, p1, p2, AngleKind::Other(Angle::from_degrees(180.0))),
+    )];
+    let initial_guesses = vec![
+        (0, 0.0),
+        (1, 0.0),
+        (2, 13.0),
+        (3, 13.0),
+        (4, 13.0),
+        (5, 13.0),
+    ];
+    let outcome = solve(
+        &constraints,
+        initial_guesses,
+        Config::default().with_max_iterations(100),
+    )
+    .unwrap();
+    assert!(outcome.warnings.first().unwrap().content == WarningContent::Degenerate);
+}
+
+#[test]
 fn points_at_angle_unique_solution() {
     // PointsAtAngle has exactly one solution unlike LinesAtAngle which has two solutions for each
     // arm that differ by π

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -1651,3 +1651,210 @@ fn lines_angle_sign_check() {
         }
     }
 }
+
+/// Returns the signed angle from (p1 - p0) to (p2 - p0), reading variable
+/// ids 0..5 = `[p0_x, p0_y, p1_x, p1_y, p2_x, p2_y]` from `vals`.
+fn points_at_angle_from_vals(vals: &[f64]) -> f64 {
+    let u = V::new(vals[2] - vals[0], vals[3] - vals[1]);
+    let v = V::new(vals[4] - vals[0], vals[5] - vals[1]);
+    u.signed_angle(v)
+}
+
+#[test]
+fn points_at_angle_already_satisfied() {
+    // Cases where the geometry already satisfies the constraint: expect 0 Newton iterations.
+    struct TestCase {
+        p1: [f64; 2], // first arm endpoint; vertex is always at origin
+        p2: [f64; 2], // second arm endpoint
+        angle: f64,
+    }
+
+    let test_cases = [
+        TestCase {
+            p1: [1.0, 0.0],
+            p2: [0.0, 2.0],
+            angle: 0.5 * PI,
+        },
+        TestCase {
+            p1: [1.0, 0.0],
+            p2: [0.0, -2.0],
+            angle: -0.5 * PI,
+        },
+        TestCase {
+            p1: [1.0, 0.0],
+            p2: [3.0, 0.0],
+            angle: 0.0,
+        },
+        TestCase {
+            p1: [1.0, 0.0],
+            p2: [-2.0, 0.0],
+            angle: PI,
+        },
+        TestCase {
+            p1: [2.0, 0.0],
+            p2: [1.0, 1.0],
+            angle: 0.25 * PI,
+        },
+    ];
+
+    let vertex = DatumPoint { x_id: 0, y_id: 1 };
+    let p1 = DatumPoint { x_id: 2, y_id: 3 };
+    let p2 = DatumPoint { x_id: 4, y_id: 5 };
+
+    for tc in &test_cases {
+        let constraints = [ConstraintRequest::highest_priority(
+            Constraint::PointsAtAngle(
+                vertex,
+                p1,
+                p2,
+                AngleKind::Other(Angle::from_radians(tc.angle)),
+            ),
+        )];
+        let initial_guesses = vec![
+            (0, 0.0),
+            (1, 0.0),
+            (2, tc.p1[0]),
+            (3, tc.p1[1]),
+            (4, tc.p2[0]),
+            (5, tc.p2[1]),
+        ];
+        let outcome = solve(
+            &constraints,
+            initial_guesses,
+            Config::default().with_max_iterations(100),
+        )
+        .unwrap_or_else(|e| panic!("failed for angle {}: {e:?}", tc.angle));
+        assert!(outcome.is_satisfied());
+        assert_eq!(
+            outcome.iterations(),
+            0,
+            "angle {} should already be satisfied (0 iterations)",
+            tc.angle
+        );
+    }
+}
+
+#[test]
+fn points_at_angle_unique_solution() {
+    // PointsAtAngle has exactly one solution unlike LinesAtAngle which has two solutions for each
+    // arm that differ by π
+    //
+    // Concretely, with target angle π/4 and u = (1,0):
+    //   - v = (1,1) direction satisfies PointsAtAngle
+    //   - v = (-1,-1) direction satisfies LinesAtAngle but not PointsAtAngle
+    //
+    // Starting from either initial condition, PointsAtAngle must converge to angle π/4.
+    let vertex = DatumPoint { x_id: 0, y_id: 1 };
+    let p1 = DatumPoint { x_id: 2, y_id: 3 };
+    let p2 = DatumPoint { x_id: 4, y_id: 5 };
+
+    let target_angle = 0.25 * PI;
+
+    let constraints = [
+        // Fix vertex and first arm
+        ConstraintRequest::highest_priority(Constraint::Fixed(0, 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(1, 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(2, 1.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(3, 0.0)),
+        ConstraintRequest::highest_priority(Constraint::PointsAtAngle(
+            vertex,
+            p1,
+            p2,
+            AngleKind::Other(Angle::from_radians(target_angle)),
+        )),
+    ];
+
+    // p2 starts on the correct side: direction (1,1), angle π/4 so already satisfied
+    let guesses_correct: Vec<(u32, f64)> =
+        vec![(0, 0.0), (1, 0.0), (2, 1.0), (3, 0.0), (4, 1.0), (5, 1.0)];
+
+    // p2 starts on the π-shifted side: direction (-1,-1), angle -3π/4.
+    // This is the other zero of LinesAtAngle, but it should not satisfy PointsAtAngle.
+    let guesses_shifted: Vec<(u32, f64)> =
+        vec![(0, 0.0), (1, 0.0), (2, 1.0), (3, 0.0), (4, -1.0), (5, -1.0)];
+
+    let outcome_correct = solve(
+        &constraints,
+        guesses_correct,
+        Config::default().with_max_iterations(100),
+    )
+    .unwrap();
+    let outcome_shifted = solve(
+        &constraints,
+        guesses_shifted,
+        Config::default().with_max_iterations(100),
+    )
+    .unwrap();
+
+    assert!(outcome_correct.is_satisfied());
+    assert!(outcome_shifted.is_satisfied());
+
+    // Both must converge to target_angle, not to target_angle - π.
+    assert_nearly_eq(
+        points_at_angle_from_vals(&outcome_correct.final_values),
+        target_angle,
+    );
+    assert_nearly_eq(
+        points_at_angle_from_vals(&outcome_shifted.final_values),
+        target_angle,
+    );
+}
+
+#[test]
+fn points_at_angle_sign_distinguishable() {
+    // Checks that PointsAtAngle respects the sign of the specified angle i.e. using +θ and -θ
+    // should place the second arm on opposite sides of the first
+    let vertex = DatumPoint { x_id: 0, y_id: 1 };
+    let p1 = DatumPoint { x_id: 2, y_id: 3 };
+    let p2 = DatumPoint { x_id: 4, y_id: 5 };
+    let theta = 0.25 * PI;
+
+    // (target_angle, initial_p2)
+    let cases: &[(f64, [f64; 2])] = &[
+        (theta, [1.0, 0.0]),
+        (-theta, [1.0, 0.0]),
+        (theta, [0.0, 1.0]),
+        (-theta, [0.0, 1.0]),
+        (theta, [-1.0, 0.0]),
+        (-theta, [-1.0, 0.0]),
+        (theta, [0.0, -1.0]),
+        (-theta, [0.0, -1.0]),
+    ];
+
+    for &(target_angle, init_p2) in cases {
+        let constraints = [
+            // Fix vertex, first arm, and length of second arm
+            ConstraintRequest::highest_priority(Constraint::Fixed(0, 0.0)),
+            ConstraintRequest::highest_priority(Constraint::Fixed(1, 0.0)),
+            ConstraintRequest::highest_priority(Constraint::Fixed(2, 1.0)),
+            ConstraintRequest::highest_priority(Constraint::Fixed(3, 0.0)),
+            ConstraintRequest::highest_priority(Constraint::Distance(vertex, p2, 1.0)),
+            ConstraintRequest::highest_priority(Constraint::PointsAtAngle(
+                vertex,
+                p1,
+                p2,
+                AngleKind::Other(Angle::from_radians(target_angle)),
+            )),
+        ];
+        let initial_guesses: Vec<(u32, f64)> = vec![
+            (0, 0.0),
+            (1, 0.0),
+            (2, 1.0),
+            (3, 0.0),
+            (4, init_p2[0]),
+            (5, init_p2[1]),
+        ];
+
+        let outcome = solve(
+            &constraints,
+            initial_guesses,
+            Config::default().with_max_iterations(100),
+        )
+        .unwrap_or_else(|e| panic!("failed for angle {target_angle}: {e:?}"));
+        assert!(outcome.is_satisfied());
+        assert_nearly_eq(
+            points_at_angle_from_vals(&outcome.final_values),
+            target_angle,
+        );
+    }
+}


### PR DESCRIPTION
Adds a new `PointsAtAngle` constraint which preserves an oriented angle between 3 points. Unlike `LinesAtAngle`, this constraint has a unique solution for each "arm" which drastically improves stability when interacting with sketches, addressing issues raised in [^1] and [^2].

Here's an example using `PointsAtAngle`:

<img width="400" alt="points-angle-demo-1" src="https://github.com/user-attachments/assets/6f802a8f-8e8b-4b39-9239-7bfee2f8ac89" />

<p></p>

And the same example using `LinesAtAngle`:

<img width="400" alt="lines-angle-demo-1" src="https://github.com/user-attachments/assets/1f672f14-615c-4cb2-b261-468092db52e8" />

<p></p>

[^1]: KittyCAD/ezpz#244
[^2]: KittyCAD/modeling-app#10964
