### PR TITLE
Release ezpz 0.2.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "ezpz"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/ezpz/Cargo.toml
+++ b/ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezpz"
-version = "0.2.24"
+version = "0.2.25"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
- Do floating-point math in libm rather than std::f64