### PR TITLE
Add per-constraint weights

### DIFF
--- a/ezpz/src/constraint_request.rs
+++ b/ezpz/src/constraint_request.rs
@@ -18,6 +18,12 @@ pub struct ConstraintRequest {
     /// 0 is highest priority.
     /// Larger numbers are lower priority.
     priority: u32,
+
+    /// Multiplicative weight applied to this constraint's residual and Jacobian
+    /// rows when assembled into the global system. Higher weights make the
+    /// solver pull harder on this constraint relative to others within the same
+    /// priority tier. Defaults to 1.0.
+    weight: f64,
 }
 
 impl ConstraintRequest {
@@ -33,6 +39,7 @@ impl ConstraintRequest {
         Self {
             constraint,
             priority,
+            weight: 1.0,
         }
     }
 
@@ -47,6 +54,17 @@ impl ConstraintRequest {
         Self::new(constraint, 0)
     }
 
+    /// Override the default unit weight.
+    /// ```
+    /// use ezpz::{Constraint, ConstraintRequest};
+    /// let req = ConstraintRequest::highest_priority(Constraint::Fixed(0, 1.0))
+    ///     .with_weight(100.0);
+    /// ```
+    pub fn with_weight(mut self, weight: f64) -> Self {
+        self.weight = weight;
+        self
+    }
+
     /// Get the underlying constraint.
     pub fn constraint(&self) -> &Constraint {
         &self.constraint
@@ -55,6 +73,11 @@ impl ConstraintRequest {
     /// Get the underlying priority.
     pub fn priority(&self) -> u32 {
         self.priority
+    }
+
+    /// Get the assigned weight.
+    pub fn weight(&self) -> f64 {
+        self.weight
     }
 
     pub(crate) fn set_from_initial_values(&mut self, initial_values: &[f64]) {

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -19,6 +19,9 @@ pub(crate) struct ConstraintEntry<'c> {
     pub id: usize,
     /// The constraint's priority. 0 is highest, larger numbers are lower.
     pub priority: u32,
+    /// Multiplicative weight applied to this constraint's residual and Jacobian
+    /// rows during global assembly. 1.0 is the unweighted default.
+    pub weight: f64,
 }
 
 impl AsRef<Constraint> for ConstraintEntry<'_> {

--- a/ezpz/src/lib.rs
+++ b/ezpz/src/lib.rs
@@ -190,6 +190,7 @@ pub(crate) fn solve_with_priority_inner<A: Analysis>(
         .map(|(id, c)| ConstraintEntry {
             constraint: c.constraint(),
             priority: c.priority(),
+            weight: c.weight(),
             id,
         })
         .collect();

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -394,7 +394,8 @@ impl Model<'_> {
                     let weighted_partial = constraint.weight * jacobian_var.partial_derivative;
                     #[cfg(feature = "dbg-jac")]
                     {
-                        dbg_matrix.last_mut().unwrap()[jacobian_var.id as usize] += weighted_partial;
+                        dbg_matrix.last_mut().unwrap()[jacobian_var.id as usize] +=
+                            weighted_partial;
                     }
                     let col = self.layout.index_of(jacobian_var.id);
 

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -341,7 +341,7 @@ impl Model<'_> {
             {
                 let this_row = row_num;
                 row_num += 1;
-                out[this_row] = **row;
+                out[this_row] = constraint.weight * **row;
             }
         }
     }
@@ -391,10 +391,10 @@ impl Model<'_> {
                 #[cfg(feature = "dbg-jac")]
                 dbg_matrix.push(vec![0.0; self.layout.num_variables]);
                 for jacobian_var in row {
+                    let weighted_partial = constraint.weight * jacobian_var.partial_derivative;
                     #[cfg(feature = "dbg-jac")]
                     {
-                        dbg_matrix.last_mut().unwrap()[jacobian_var.id as usize] +=
-                            jacobian_var.partial_derivative;
+                        dbg_matrix.last_mut().unwrap()[jacobian_var.id as usize] += weighted_partial;
                     }
                     let col = self.layout.index_of(jacobian_var.id);
 
@@ -405,7 +405,7 @@ impl Model<'_> {
                     // Search for our row within this column's entries.
                     let idx = col_range.find(|idx| row_indices[*idx] == this_row).unwrap();
                     // Found the right position; accumulate the partials.
-                    self.jc.vals[idx] += jacobian_var.partial_derivative;
+                    self.jc.vals[idx] += weighted_partial;
                 }
             }
         }
@@ -444,6 +444,7 @@ mod tests {
             constraint: &constraint,
             id: 42,
             priority: 0,
+            weight: 1.0,
         };
 
         let all_variables = vec![0, 2]; // Only X components, missing Y components.

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -266,7 +266,7 @@ fn weight_biases_inconsistent_solution() {
         ConstraintRequest::highest_priority(Constraint::Fixed(var_id, 100.0)).with_weight(100.0),
     ];
     let initial_guesses = vec![(var_id, 50.0)];
-    
+
     let solved = solve(&constraints, initial_guesses, Config::default()).unwrap();
     let final_value = solved.final_values()[0];
     assert!(

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -253,6 +253,37 @@ fn inconsistent() {
 }
 
 #[test]
+fn weight_biases_inconsistent_solution() {
+    // Two competing Fixed constraints on the same variable at the same priority:
+    // target=0 with default weight 1, and target=100 with weight 100. With equal
+    // weights the least-squares minimum sits at the midpoint (50). With 100x on
+    // the second target the solver should pull almost all the way to 100.
+    let mut ids = IdGenerator::default();
+    let var_id = ids.next_id();
+
+    let constraints = vec![
+        ConstraintRequest::highest_priority(Constraint::Fixed(var_id, 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(var_id, 100.0)).with_weight(100.0),
+    ];
+    let initial_guesses = vec![(var_id, 50.0)];
+    
+    let solved = solve(&constraints, initial_guesses, Config::default()).unwrap();
+    let final_value = solved.final_values()[0];
+    assert!(
+        final_value > 99.0,
+        "weighted target should dominate; got {final_value}",
+    );
+
+    // Equal weights for comparison: should settle at the midpoint.
+    let baseline = vec![
+        ConstraintRequest::highest_priority(Constraint::Fixed(var_id, 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(var_id, 100.0)),
+    ];
+    let baseline_solved = solve(&baseline, vec![(var_id, 50.0)], Config::default()).unwrap();
+    assert_nearly_eq(baseline_solved.final_values()[0], 50.0);
+}
+
+#[test]
 fn circle() {
     let solved = run("circle");
     assert!(solved.is_satisfied());

--- a/ezpz/src/warnings.rs
+++ b/ezpz/src/warnings.rs
@@ -115,11 +115,13 @@ mod tests {
                 constraint: &parallel,
                 id: 7,
                 priority: 0,
+                weight: 1.0,
             },
             ConstraintEntry {
                 constraint: &perpendicular,
                 id: 9,
                 priority: 0,
+                weight: 1.0,
             },
         ];
 


### PR DESCRIPTION
Adds a weight value to constraint types, allowing their relative influence to be increased/decreased. 

This allows us to address an issue raised in [this thread](https://kittycadworkspace.slack.com/archives/C026992J5FC/p1777823586900579?thread_ts=1777677085.114189&cid=C026992J5FC) where sketches with unshared vertices can visibly come apart during interaction. Increasing the weight of coincidence constraints mitigates the issue e.g.

[sketch-interaction-weighting-1.webm](https://github.com/user-attachments/assets/56e92f14-2c93-4427-9710-a70761e0c321)