### PR TITLE
Use rank-revealing QR for freedom analysis

### DIFF
--- a/ezpz/src/analysis.rs
+++ b/ezpz/src/analysis.rs
@@ -48,6 +48,7 @@ impl FreedomAnalysis {
     pub(crate) fn new(underconstrained: Vec<crate::Id>) -> Self {
         Self { underconstrained }
     }
+
     /// Is any variable in the system underconstrained?
     pub fn is_underconstrained(&self) -> bool {
         !self.underconstrained.is_empty()

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -103,7 +103,7 @@ impl Layout {
 
 /// A Jacobian cache.
 /// Stores the Jacobian so we don't constantly reallocate it.
-struct Jc {
+struct JacobianCache {
     /// The symbolic structure of the matrix (i.e. which cells are non-zero).
     /// This way the matrix's structure is only allocated once, and reused
     /// between different Jacobian calculations.
@@ -117,7 +117,7 @@ struct Jc {
 /// Note that the initial values of each variable are required for Tikhonov regularization.
 pub(crate) struct Model<'c> {
     layout: Layout,
-    jc: Jc,
+    jacobian_cache: JacobianCache,
     constraints: &'c [ConstraintEntry<'c>],
     row0_scratch: Vec<JacobianVar>,
     row1_scratch: Vec<JacobianVar>,
@@ -252,7 +252,7 @@ impl<'c> Model<'c> {
         // the solver takes smaller and smaller steps.
         let lambda_i = build_lambda_i(layout.num_variables);
 
-        let jc = Jc {
+        let jc = JacobianCache {
             vals: vec![0.0; sym.compute_nnz()], // We have a nonzero count util.
             sym,
         };
@@ -264,7 +264,7 @@ impl<'c> Model<'c> {
         Ok(Self {
             warnings: Default::default(),
             layout,
-            jc,
+            jacobian_cache: jc,
             constraints,
             row0_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
             row1_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
@@ -350,7 +350,7 @@ impl Model<'_> {
     fn refresh_jacobian(&mut self, current_assignments: &[f64]) {
         // To enable per-variable partial derivative accumulation (i.e. local to global
         // Jacobian assembly), we need to zero out the Jacobian values first.
-        self.jc.vals.fill(0.0);
+        self.jacobian_cache.vals.fill(0.0);
 
         // Allocate some scratch space for the Jacobian calculations, so that we can
         // do one allocation here and then won't need any allocations per-row or per-column.
@@ -400,13 +400,13 @@ impl Model<'_> {
                     let col = self.layout.index_of(jacobian_var.id);
 
                     // Find where this (row_num, col) entry should go in the sparse structure.
-                    let mut col_range = self.jc.sym.col_range(col);
-                    let row_indices = self.jc.sym.row_idx();
+                    let mut col_range = self.jacobian_cache.sym.col_range(col);
+                    let row_indices = self.jacobian_cache.sym.row_idx();
 
                     // Search for our row within this column's entries.
                     let idx = col_range.find(|idx| row_indices[*idx] == this_row).unwrap();
                     // Found the right position; accumulate the partials.
-                    self.jc.vals[idx] += weighted_partial;
+                    self.jacobian_cache.vals[idx] += weighted_partial;
                 }
             }
         }

--- a/ezpz/src/solver/find_dof.rs
+++ b/ezpz/src/solver/find_dof.rs
@@ -1,16 +1,20 @@
 //! Finding degrees of freedom and assessing which variables are underconstrained.
-use faer::sparse::SparseColMatRef;
+use faer::{
+    Mat, MatRef,
+    linalg::solvers::{ColPivQr, Qr},
+    mat::{AsMatMut, AsMatRef},
+    perm::permute_rows,
+    sparse::SparseColMatRef,
+};
 
 use crate::{FreedomAnalysis, NonLinearSystemError, solver::Model};
 
+const TOLERANCE_BASE: f64 = 1E-8;
+
 impl Model<'_> {
     pub(crate) fn freedom_analysis(&self) -> Result<FreedomAnalysis, NonLinearSystemError> {
-        // First step is to compute the SVD.
-        // Faer has a sparse SVD algorithm called `partial_svd`, but I haven't been
-        // able to get it working properly yet.
-        // For now, we'll just use a dense SVD algorithm.
-        // This is VERY SLOW for large matrices.
-        let j_sparse = SparseColMatRef::new(self.jc.sym.as_ref(), &self.jc.vals);
+        let j_sparse =
+            SparseColMatRef::new(self.jacobian_cache.sym.as_ref(), &self.jacobian_cache.vals);
         let j_dense = j_sparse.to_dense();
         let nvars = self.layout.num_variables;
         debug_assert_eq!(
@@ -19,59 +23,79 @@ impl Model<'_> {
             "Jacobian was malformed, Adam messed something up here."
         );
 
-        // SVD decomposes `J` into `J = UΣVᵀ`.
-        let svd = j_dense.svd().map_err(NonLinearSystemError::FaerSvd)?;
-        let svd_s = svd.S();
-        let svd_v = svd.V();
-
-        let underconstrained = calculate(svd_s, svd_v, nvars)?;
+        let nullspace = orthonormal_nullspace(j_dense.as_mat_ref(), nvars)?;
+        let underconstrained = underconstrained_variables(nullspace.as_mat_ref(), nvars);
         Ok(FreedomAnalysis::new(underconstrained))
     }
 }
 
-fn calculate(
-    svd_sigma: faer::diag::generic::Diag<faer::diag::Ref<'_, f64>>,
-    svd_v: faer::mat::generic::Mat<faer::mat::Ref<'_, f64>>,
+fn orthonormal_nullspace(
+    jacobian: MatRef<'_, f64>,
     nvars: usize,
-) -> Result<Vec<crate::Id>, NonLinearSystemError> {
-    // These are the 'singular values'.
-    let sigma_col = svd_sigma.column_vector();
+) -> Result<Mat<f64>, NonLinearSystemError> {
+    let qr = ColPivQr::new(jacobian);
+    let r = qr.R();
+    let ndiag = r.nrows().min(r.ncols());
 
-    // The system is underconstrained if there's too many singular values
-    // close to 0. How close to 0? The tolerance should be derived from
-    // the largest singular value.
-    let largest_singular_value = sigma_col
-        .iter()
-        .copied()
+    let largest_diagonal = (0..ndiag)
+        .map(|i| r.get(i, i).abs())
         .reduce(libm::fmax)
         .ok_or(NonLinearSystemError::EmptySystemNotAllowed)?;
-    let tolerance = 1e-8 * largest_singular_value;
+    let tolerance = TOLERANCE_BASE * largest_diagonal;
+    let rank = (0..ndiag)
+        .take_while(|&i| r.get(i, i).abs() > tolerance)
+        .count();
+    let nullity = nvars - rank;
 
-    let rank = sigma_col.iter().filter(|&&s| s > tolerance).count();
+    let mut permuted_nullspace = Mat::zeros(nvars, nullity);
+    for free_col in 0..nullity {
+        let free_var = rank + free_col;
+        permuted_nullspace[(free_var, free_col)] = 1.0;
 
-    // The degrees of freedom = nvars - rank;
-    // The rank is a measure of how sensitive the Jacobian is in each direction.
-    // If there's any direction where the Jacobian is sensitive, then tweaking the values
-    // in that dimension will change the result. This is what we'd expect in a well-constrained system.
-    // On the other hand, if the Jacobian DOESN'T change along one direction, that implies the direction
-    // doesn't affect the residual at all. That's basically exactly what a degree of freedom means.
+        // For J P^T = Q R, solve R11 x + R12 z = 0 with one free
+        // coordinate of z set to 1. This gives a basis for null(J P^T).
+        for i in (0..rank).rev() {
+            let mut rhs = *r.get(i, free_var);
+            for j in (i + 1)..rank {
+                rhs += r.get(i, j) * permuted_nullspace[(j, free_col)];
+            }
 
-    // Nullspace column indices in V, as in J = U.sigma.V in the SVD decomposition.
-    let degrees_of_freedom: Vec<usize> = (rank..nvars).collect();
+            let diagonal = r.get(i, i);
+            if diagonal.abs() <= tolerance {
+                return Err(NonLinearSystemError::EmptySystemNotAllowed);
+            }
+            permuted_nullspace[(i, free_col)] = -rhs / diagonal;
+        }
+    }
+
+    let mut nullspace = Mat::zeros(nvars, nullity);
+    permute_rows(
+        nullspace.as_mat_mut(),
+        permuted_nullspace.as_mat_ref(),
+        qr.P().inverse(),
+    );
+
+    Ok(Qr::new(nullspace.as_mat_ref()).compute_thin_Q())
+}
+
+fn underconstrained_variables(
+    nullspace: faer::mat::generic::Mat<faer::mat::Ref<'_, f64>>,
+    nvars: usize,
+) -> Vec<crate::Id> {
+    debug_assert_eq!(nvars, nullspace.nrows());
 
     // Compute participation norm for each variable.
     // If a variable's participation is basically zero, then it's constrained.
     // If it's nonzero, then it moves in some DOF and is unconstrained.
-    let participation: Vec<_> = (0..nvars)
+    let participation: Vec<f64> = (0..nvars)
         .map(|j| {
-            let mut sum_sq = 0.0f64;
-
-            for &k in &degrees_of_freedom {
-                // V[j, k] is the component of variable j for the k-th DOF.
-                let v_jk = svd_v.get(j, k);
-                sum_sq += v_jk * v_jk;
-            }
-            sum_sq.sqrt()
+            (0..nullspace.ncols())
+                .map(|k| {
+                    let n_jk = nullspace.get(j, k);
+                    n_jk * n_jk
+                })
+                .sum::<f64>()
+                .sqrt()
         })
         .collect();
     let max_participation = participation.iter().copied().fold(0.0, libm::fmax);
@@ -84,5 +108,5 @@ fn calculate(
         .map(|x| x as u32)
         .collect();
 
-    Ok(underconstrained)
+    underconstrained
 }

--- a/ezpz/src/solver/find_dof.rs
+++ b/ezpz/src/solver/find_dof.rs
@@ -103,10 +103,8 @@ fn underconstrained_variables(
     // Relative threshold to classify variables
     let var_tol = 1e-3 * max_participation;
 
-    let underconstrained = (0..nvars)
+    (0..nvars)
         .filter(|&j| participation[j] > var_tol)
         .map(|x| x as u32)
-        .collect();
-
-    underconstrained
+        .collect()
 }

--- a/ezpz/src/solver/find_dof.rs
+++ b/ezpz/src/solver/find_dof.rs
@@ -87,24 +87,18 @@ fn underconstrained_variables(
     // Compute participation norm for each variable.
     // If a variable's participation is basically zero, then it's constrained.
     // If it's nonzero, then it moves in some DOF and is unconstrained.
-    let participation: Vec<f64> = (0..nvars)
-        .map(|j| {
-            (0..nullspace.ncols())
-                .map(|k| {
-                    let n_jk = nullspace.get(j, k);
-                    n_jk * n_jk
-                })
-                .sum::<f64>()
-                .sqrt()
-        })
+    let participation: Vec<f64> = nullspace
+        .row_iter()
+        .map(|row| row.squared_norm_l2())
         .collect();
     let max_participation = participation.iter().copied().fold(0.0, libm::fmax);
 
     // Relative threshold to classify variables
     let var_tol = 1e-3 * max_participation;
+    let squared_tol = var_tol * var_tol;
 
     (0..nvars)
-        .filter(|&j| participation[j] > var_tol)
+        .filter(|&j| participation[j] > squared_tol)
         .map(|x| x as u32)
         .collect()
 }

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -51,7 +51,8 @@ impl Model<'_> {
                b = -Jᵀr
             */
 
-            let j = SparseColMatRef::new(self.jc.sym.as_ref(), &self.jc.vals);
+            let j =
+                SparseColMatRef::new(self.jacobian_cache.sym.as_ref(), &self.jacobian_cache.vals);
             // TODO: Is there any way to transpose `j` and keep it in column-major?
             // Converting from row- to column-major might not be necessary.
             let jtj = j.transpose().to_col_major()? * j;


### PR DESCRIPTION
This PR replaces the full SVD-based degree-of-freedom analysis with a column-pivoted QR approach. After QR we estimate the Jacobian rank and construct a nullspace basis from the dependent columns. We then orthonormalize that basis before computing per-variable participation, preserving the same broad interpretation as before: variables are marked underconstrained when they participate meaningfully in the Jacobian nullspace.

This is faster because QR is cheaper than full SVD and avoids computing singular vectors that are not directly needed for the analysis. Somewhat disappointingly this does not significantly move the needle on general performance, although it does speed up the analysis focused benchmarks:

<img width="1192" height="378" alt="image" src="https://github.com/user-attachments/assets/b37bc8c7-45ed-4270-a39a-3262c1352b8b" />
