### PR TITLE
Expose best-effort solve output

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -203,6 +203,7 @@ fn print_failure_output(outcome: FailureOutcome) {
         warnings,
         num_vars,
         num_eqs,
+        ..
     } = outcome;
     print_warnings(&warnings);
     print_problem_size(num_vars, num_eqs);

--- a/ezpz/src/lib.rs
+++ b/ezpz/src/lib.rs
@@ -236,6 +236,9 @@ pub(crate) fn solve_with_priority_inner<A: Analysis>(
             }
             // If this constraint couldn't be solved,
             Err(e) => {
+                if e.best_effort().is_some() {
+                    return Err(e);
+                }
                 // then return a previous solved system with fewer (higher-priority) constraints,
                 // or if there was no such previous system, then this was the first run,
                 // and we should just return the error.
@@ -279,6 +282,7 @@ fn solve_inner<A: Analysis>(
         Err(error) => {
             return Err(FailureOutcome {
                 error,
+                best_effort: None,
                 warnings,
                 num_vars,
                 num_eqs,
@@ -286,20 +290,75 @@ fn solve_inner<A: Analysis>(
         }
     };
 
-    let mut unsatisfied: Vec<usize> = Vec::new();
+    let priority_solved = constraints
+        .iter()
+        .map(|c| c.priority)
+        .max()
+        .unwrap_or_default();
     let outcome = model.solve_gauss_newton(&mut values, config);
     warnings.extend(model.warnings.lock().unwrap().drain(..));
     let success = match outcome {
         Ok(o) => o,
         Err(error) => {
+            let best_effort = matches!(error, NonLinearSystemError::DidNotConverge).then(|| {
+                solve_outcome_from_values(
+                    constraints,
+                    values,
+                    config.max_iterations(),
+                    warnings.clone(),
+                    priority_solved,
+                    config,
+                )
+            });
             return Err(FailureOutcome {
                 error,
+                best_effort,
                 warnings,
                 num_vars,
                 num_eqs,
             });
         }
     };
+    let analysis = match A::analyze(model) {
+        Ok(o) => o,
+        Err(error) => {
+            let best_effort = Some(solve_outcome_from_values(
+                constraints,
+                values,
+                success.iterations,
+                warnings.clone(),
+                priority_solved,
+                config,
+            ));
+            return Err(FailureOutcome {
+                error,
+                best_effort,
+                warnings,
+                num_vars,
+                num_eqs,
+            });
+        }
+    };
+    let outcome = solve_outcome_from_values(
+        constraints,
+        values,
+        success.iterations,
+        warnings,
+        priority_solved,
+        config,
+    );
+    Ok(SolveOutcomeAnalysis { outcome, analysis })
+}
+
+fn solve_outcome_from_values(
+    constraints: &[ConstraintEntry<'_>],
+    values: Vec<f64>,
+    iterations: usize,
+    warnings: Vec<Warning>,
+    priority_solved: u32,
+    config: Config,
+) -> SolveOutcome {
+    let mut unsatisfied: Vec<usize> = Vec::new();
     let cs: Vec<_> = constraints.iter().map(|c| c.constraint).collect();
     let layout = solver::Layout::new(&Vec::new(), cs.as_slice(), config);
     for constraint in constraints {
@@ -323,33 +382,14 @@ fn solve_inner<A: Analysis>(
             unsatisfied.push(constraint.id);
         }
     }
-    let analysis = match A::analyze(model) {
-        Ok(o) => o,
-        Err(error) => {
-            return Err(FailureOutcome {
-                error,
-                warnings,
-                num_vars,
-                num_eqs,
-            });
-        }
-    };
 
-    let lowest_priority = constraints
-        .iter()
-        .map(|c| c.priority)
-        .max()
-        .unwrap_or_default();
-    Ok(SolveOutcomeAnalysis {
-        outcome: SolveOutcome {
-            priority_solved: lowest_priority,
-            unsatisfied,
-            final_values: values,
-            iterations: success.iterations,
-            warnings,
-        },
-        analysis,
-    })
+    SolveOutcome {
+        priority_solved,
+        unsatisfied,
+        final_values: values,
+        iterations,
+        warnings,
+    }
 }
 
 fn is_satisfied(residual_dim: usize, residuals: [f64; 3]) -> bool {

--- a/ezpz/src/solve_outcome.rs
+++ b/ezpz/src/solve_outcome.rs
@@ -119,6 +119,8 @@ impl AsRef<SolveOutcome> for SolveOutcomeFreedomAnalysis {
 pub struct FailureOutcome {
     /// The error that stopped the system from being solved.
     pub error: NonLinearSystemError,
+    /// Best-effort values from the final solver iteration, when available.
+    pub best_effort: Option<SolveOutcome>,
     /// Other warnings which might have contributed,
     /// or might be suboptimal for other reasons.
     pub warnings: Vec<Warning>,
@@ -132,6 +134,11 @@ impl FailureOutcome {
     /// The error that stopped the system from being solved.
     pub fn error(&self) -> &NonLinearSystemError {
         &self.error
+    }
+
+    /// Best-effort values from the final solver iteration, when available.
+    pub fn best_effort(&self) -> Option<&SolveOutcome> {
+        self.best_effort.as_ref()
     }
 
     /// Other warnings which might have contributed,

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -39,6 +39,11 @@ pub struct Config {
 
 impl Config {
     /// How many iteration rounds before the solver gives up?
+    pub(crate) fn max_iterations(&self) -> usize {
+        self.max_iterations
+    }
+
+    /// How many iteration rounds before the solver gives up?
     pub fn with_max_iterations(mut self, value: usize) -> Self {
         self.max_iterations = value;
         self

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -284,6 +284,51 @@ fn weight_biases_inconsistent_solution() {
 }
 
 #[test]
+fn non_convergence_exposes_best_effort_values() {
+    let mut ids = IdGenerator::default();
+    let p = DatumPoint::new(&mut ids);
+    let q = DatumPoint::new(&mut ids);
+    let constraints = vec![
+        ConstraintRequest::highest_priority(Constraint::Fixed(p.id_x(), 0.0)),
+        ConstraintRequest::highest_priority(Constraint::Fixed(p.id_y(), 0.0)),
+        ConstraintRequest::new(Constraint::Distance(p, q, 10.0), 1),
+    ];
+    let initial_guesses = vec![
+        (p.id_x(), 0.0),
+        (p.id_y(), 0.0),
+        (q.id_x(), 20.0),
+        (q.id_y(), 20.0),
+    ];
+    let initial_values = initial_guesses
+        .iter()
+        .map(|(_, guess)| *guess)
+        .collect::<Vec<_>>();
+
+    let failure = solve(
+        &constraints,
+        initial_guesses,
+        Config::default().with_max_iterations(1),
+    )
+    .expect_err("one iteration should not converge this solve");
+
+    assert!(matches!(
+        failure.error(),
+        NonLinearSystemError::DidNotConverge
+    ));
+    let best_effort = failure
+        .best_effort()
+        .expect("non-convergence should return the last solver iterate");
+    assert_eq!(best_effort.final_values().len(), initial_values.len());
+    assert!(
+        best_effort
+            .final_values()
+            .iter()
+            .zip(initial_values)
+            .any(|(actual, initial)| (actual - initial).abs() > EPSILON)
+    );
+}
+
+#[test]
 fn circle() {
     let solved = run("circle");
     assert!(solved.is_satisfied());


### PR DESCRIPTION
## Summary

Expose the final solver iterate on `FailureOutcome` when ezpz stops because it hit the iteration limit (`DidNotConverge`).

This lets callers render and persist the best least-squares state produced by the solver instead of falling back to the original initial guesses.

## Details

- Adds `FailureOutcome::best_effort()` returning an optional `SolveOutcome`.
- Populates `best_effort` for `DidNotConverge` using the current values after the final Gauss-Newton iteration.
- Propagates non-convergence failures that have `best_effort` instead of hiding them behind the previous higher-priority solve.
- Reuses the normal unsatisfied-constraint computation for both successful and best-effort outcomes.
- Adds a regression test proving non-convergence exposes values that moved away from the initial guesses, even when a higher-priority subset solved first.
- Updates the CLI failure-output destructuring for the new `FailureOutcome` field.

## Validation

- `cargo test --manifest-path ezpz/Cargo.toml non_convergence_exposes_best_effort_values`
- `just lint`
- `just test-with-coverage`