### PR TITLE
Expose via the most minimal wasm layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+SPECIFICATION.txt
 target/
 mutants.out*
 node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,8 @@ version = "0.1.0"
 dependencies = [
  "ezpz",
  "faer",
+ "serde",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
 ]
 
@@ -1743,6 +1745,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "libm",
  "mutants",
  "proptest",
+ "serde",
  "thiserror 2.0.18",
  "twenty-twenty",
  "winnow",

--- a/ezpz-wasm/Cargo.toml
+++ b/ezpz-wasm/Cargo.toml
@@ -14,4 +14,6 @@ bench = false
 [dependencies]
 faer = { version = "0.24.0", default-features = false, features = ["std", "sparse-linalg"] }
 ezpz = { path = "../ezpz" }
+serde = { version = "1.0", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"

--- a/ezpz-wasm/LICENSE
+++ b/ezpz-wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ezpz-wasm/index.html
+++ b/ezpz-wasm/index.html
@@ -2,12 +2,11 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8">
-    <title>hello-wasm example</title>
+    <title>ezpz wasm</title>
   </head>
   <body>
     <h1>ezpz playground</h1>
-    <div id="message"></div>
-    <pre id="file-content"></pre>
+    <pre id="output"></pre>
     <script type="module" src="main.js"></script>
   </body>
 </html>

--- a/ezpz-wasm/main.js
+++ b/ezpz-wasm/main.js
@@ -1,16 +1,18 @@
-import init, { hello, benchmark, test_faer } from "./pkg/ezpz_wasm.js";
-init().then(() => {
-  console.log("Hello! Code is running.");
-  const messageDisplay = document.getElementById("message");
-  console.log("Calling test_faer");
-  messageDisplay.textContent=test_faer();
+import init, { solveText } from "./pkg/ezpz_wasm.js";
 
-  console.log("Calling benchmark");
-  const startTime = performance.now()
-  const runs=100;
-  for (let i = 0; i < runs; i++) {
-    benchmark();
-  }
-  const endTime = performance.now()
-  console.log(`Call to 'benchmark' took ${(endTime - startTime)/runs} milliseconds each (ran ${runs} times)`)
+const source = `
+point p
+point q
+p.x = 0
+p.y = 0
+distance(p, q, 4)
+
+p roughly (0, 0)
+q roughly (3, 2)
+`;
+
+init().then(() => {
+  const output = document.getElementById("output");
+  const result = solveText(source);
+  output.textContent = JSON.stringify(result, null, 2);
 });

--- a/ezpz-wasm/src/lib.rs
+++ b/ezpz-wasm/src/lib.rs
@@ -87,6 +87,7 @@ impl From<WasmConfig> for Config {
 
 impl From<&NonLinearSystemError> for WasmNonLinearSystemError {
     fn from(value: &NonLinearSystemError) -> Self {
+        #[allow(unreachable_patterns)]
         match value {
             NonLinearSystemError::NotFound(id) => Self::NotFound(*id),
             NonLinearSystemError::WrongNumberGuesses { labels, guesses } => {
@@ -116,6 +117,9 @@ impl From<&NonLinearSystemError> for WasmNonLinearSystemError {
             },
             NonLinearSystemError::DidNotConverge => Self::DidNotConverge,
             NonLinearSystemError::EmptySystemNotAllowed => Self::EmptySystemNotAllowed,
+            _ => Self::Faer {
+                message: value.to_string(),
+            },
         }
     }
 }

--- a/ezpz-wasm/src/lib.rs
+++ b/ezpz-wasm/src/lib.rs
@@ -1,9 +1,6 @@
 use std::str::FromStr;
 
-use ezpz::{
-    Config, ConstraintRequest, FailureOutcome, NonLinearSystemError, SolveOutcome,
-    SolveOutcomeFreedomAnalysis, textual,
-};
+use ezpz::{Config, ConstraintRequest, FailureOutcome, NonLinearSystemError, textual};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use wasm_bindgen::prelude::*;
 
@@ -157,33 +154,17 @@ fn parse_config(config: Option<JsValue>) -> JsResult<Config> {
     }
 }
 
-fn parse_requests(value: JsValue) -> JsResult<Vec<ConstraintRequest>> {
-    deserialize(value)
-}
-
-fn parse_initial_guesses(value: JsValue) -> JsResult<Vec<(ezpz::Id, f64)>> {
-    deserialize(value)
-}
-
-fn serialize_solve_outcome(outcome: &SolveOutcome) -> JsResult<JsValue> {
-    serialize(outcome)
-}
-
-fn serialize_solve_outcome_analysis(outcome: &SolveOutcomeFreedomAnalysis) -> JsResult<JsValue> {
-    serialize(outcome)
-}
-
 #[wasm_bindgen]
 pub fn solve(
     requests: JsValue,
     initial_guesses: JsValue,
     config: Option<JsValue>,
 ) -> JsResult<JsValue> {
-    let requests = parse_requests(requests)?;
-    let initial_guesses = parse_initial_guesses(initial_guesses)?;
+    let requests: Vec<ConstraintRequest> = deserialize(requests)?;
+    let initial_guesses: Vec<(ezpz::Id, f64)> = deserialize(initial_guesses)?;
     let config = parse_config(config)?;
     match ezpz::solve(&requests, initial_guesses, config) {
-        Ok(outcome) => serialize_solve_outcome(&outcome),
+        Ok(outcome) => serialize(&outcome),
         Err(error) => Err(failure_to_js(&error)),
     }
 }
@@ -194,11 +175,11 @@ pub fn solve_analysis(
     initial_guesses: JsValue,
     config: Option<JsValue>,
 ) -> JsResult<JsValue> {
-    let requests = parse_requests(requests)?;
-    let initial_guesses = parse_initial_guesses(initial_guesses)?;
+    let requests: Vec<ConstraintRequest> = deserialize(requests)?;
+    let initial_guesses: Vec<(ezpz::Id, f64)> = deserialize(initial_guesses)?;
     let config = parse_config(config)?;
     match ezpz::solve_analysis(&requests, initial_guesses, config) {
-        Ok(outcome) => serialize_solve_outcome_analysis(&outcome),
+        Ok(outcome) => serialize(&outcome),
         Err(error) => Err(failure_to_js(&error)),
     }
 }

--- a/ezpz-wasm/src/lib.rs
+++ b/ezpz-wasm/src/lib.rs
@@ -1,11 +1,8 @@
 use std::str::FromStr;
 
 use ezpz::{
-    CircleSide, Config, Constraint, ConstraintRequest, FailureOutcome, FreedomAnalysis, Id,
-    LineSide, NonLinearSystemError, SolveOutcome, SolveOutcomeFreedomAnalysis, Warning,
-    WarningContent,
-    datatypes::{Angle, AngleKind, inputs::*, outputs::*},
-    textual,
+    Config, ConstraintRequest, FailureOutcome, NonLinearSystemError, SolveOutcome,
+    SolveOutcomeFreedomAnalysis, textual,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use wasm_bindgen::prelude::*;
@@ -20,180 +17,30 @@ struct WasmConfig {
     step_tolerance: Option<f64>,
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-enum WasmAngleUnit {
-    Degrees,
-    Radians,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmAngle {
-    value: f64,
-    unit: WasmAngleUnit,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmDatumDistance {
-    id: Id,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmDatumPoint {
-    x_id: Id,
-    y_id: Id,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmDatumLineSegment {
-    p0: WasmDatumPoint,
-    p1: WasmDatumPoint,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmDatumCircle {
-    center: WasmDatumPoint,
-    radius: WasmDatumDistance,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmDatumCircularArc {
-    center: WasmDatumPoint,
-    start: WasmDatumPoint,
-    end: WasmDatumPoint,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-enum WasmAngleKind {
-    Parallel,
-    Perpendicular,
-    Other(WasmAngle),
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-enum WasmLineSide {
-    Undefined,
-    Left,
-    Right,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-enum WasmCircleSide {
-    Undefined,
-    Exterior,
-    Interior,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", content = "data")]
-enum WasmConstraint {
-    LineTangentToCircle(WasmDatumLineSegment, WasmDatumCircle, WasmLineSide),
-    CircleTangentToCircle(WasmDatumCircle, WasmDatumCircle, WasmCircleSide),
-    Distance(WasmDatumPoint, WasmDatumPoint, f64),
-    DistanceVar(WasmDatumPoint, WasmDatumPoint, WasmDatumDistance),
-    VerticalDistance(WasmDatumPoint, WasmDatumPoint, f64),
-    HorizontalDistance(WasmDatumPoint, WasmDatumPoint, f64),
-    Vertical(WasmDatumLineSegment),
-    Horizontal(WasmDatumLineSegment),
-    LinesAtAngle(WasmDatumLineSegment, WasmDatumLineSegment, WasmAngleKind),
-    Fixed(Id, f64),
-    ScalarEqual(Id, Id),
-    PointsCoincident(WasmDatumPoint, WasmDatumPoint),
-    CircleRadius(WasmDatumCircle, f64),
-    LinesEqualLength(WasmDatumLineSegment, WasmDatumLineSegment),
-    ArcRadius(WasmDatumCircularArc, f64),
-    Arc(WasmDatumCircularArc),
-    Midpoint(WasmDatumLineSegment, WasmDatumPoint),
-    PointLineDistance(WasmDatumPoint, WasmDatumLineSegment, f64),
-    VerticalPointLineDistance(WasmDatumPoint, WasmDatumLineSegment, f64),
-    HorizontalPointLineDistance(WasmDatumPoint, WasmDatumLineSegment, f64),
-    Symmetric(WasmDatumLineSegment, WasmDatumPoint, WasmDatumPoint),
-    PointArcCoincident(WasmDatumCircularArc, WasmDatumPoint),
-    ArcLength(WasmDatumCircularArc, f64),
-    ArcAngle(WasmDatumCircularArc, WasmAngle),
-    PointsAtAngle(
-        WasmDatumPoint,
-        WasmDatumPoint,
-        WasmDatumPoint,
-        WasmAngleKind,
-    ),
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmConstraintRequest {
-    constraint: WasmConstraint,
-    priority: u32,
-    weight: f64,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmPoint {
-    x: f64,
-    y: f64,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmCircle {
-    radius: f64,
-    center: WasmPoint,
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize)]
-struct WasmArc {
-    a: WasmPoint,
-    b: WasmPoint,
-    center: WasmPoint,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", content = "data")]
-enum WasmWarningContent {
-    Degenerate,
-    ShouldBeParallel(WasmAngle),
-    ShouldBePerpendicular(WasmAngle),
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmWarning {
-    about_constraint: Option<usize>,
-    content: WasmWarningContent,
-    message: String,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmSolveOutcome {
-    unsatisfied: Vec<usize>,
-    final_values: Vec<f64>,
-    iterations: usize,
-    warnings: Vec<WasmWarning>,
-    priority_solved: u32,
-    is_satisfied: bool,
-    is_unsatisfied: bool,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmFreedomAnalysis {
-    underconstrained: Vec<Id>,
-    is_underconstrained: bool,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmSolveOutcomeFreedomAnalysis {
-    analysis: WasmFreedomAnalysis,
-    outcome: WasmSolveOutcome,
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "data")]
 enum WasmNonLinearSystemError {
-    NotFound(Id),
-    WrongNumberGuesses { labels: usize, guesses: usize },
-    MissingGuess { constraint_id: usize, variable: Id },
-    FaerMatrix { message: String },
-    Faer { message: String },
-    FaerSolve { message: String },
-    FaerSvd { message: String },
+    NotFound(ezpz::Id),
+    WrongNumberGuesses {
+        labels: usize,
+        guesses: usize,
+    },
+    MissingGuess {
+        constraint_id: usize,
+        variable: ezpz::Id,
+    },
+    FaerMatrix {
+        message: String,
+    },
+    Faer {
+        message: String,
+    },
+    FaerSolve {
+        message: String,
+    },
+    FaerSvd {
+        message: String,
+    },
     DidNotConverge,
     EmptySystemNotAllowed,
 }
@@ -202,62 +49,15 @@ enum WasmNonLinearSystemError {
 struct WasmFailureOutcome {
     error: WasmNonLinearSystemError,
     message: String,
-    warnings: Vec<WasmWarning>,
+    warnings: Vec<ezpz::Warning>,
     num_vars: usize,
     num_eqs: usize,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "data")]
-enum WasmTextualError {
-    MissingGuess { label: String },
-    UnusedGuesses { labels: Vec<String> },
-    UndefinedPoint { label: String },
+enum WasmStringError {
     Parse { message: String },
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmNamedPoint {
-    label: String,
-    point: WasmPoint,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmNamedCircle {
-    label: String,
-    circle: WasmCircle,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmNamedArc {
-    label: String,
-    arc: WasmArc,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmNamedLine {
-    p0: String,
-    p1: String,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmTextualOutcome {
-    unsatisfied: Vec<usize>,
-    iterations: usize,
-    warnings: Vec<WasmWarning>,
-    points: Vec<WasmNamedPoint>,
-    circles: Vec<WasmNamedCircle>,
-    arcs: Vec<WasmNamedArc>,
-    lines: Vec<WasmNamedLine>,
-    num_vars: usize,
-    num_eqs: usize,
-    priority_solved: u32,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct WasmTextualOutcomeAnalysis {
-    analysis: WasmFreedomAnalysis,
-    outcome: WasmTextualOutcome,
 }
 
 fn serialize<T: Serialize>(value: &T) -> JsResult<JsValue> {
@@ -285,244 +85,6 @@ impl From<WasmConfig> for Config {
             out = out.with_step_tolerance(step_tolerance);
         }
         out
-    }
-}
-
-impl From<WasmAngle> for Angle {
-    fn from(value: WasmAngle) -> Self {
-        match value.unit {
-            WasmAngleUnit::Degrees => Self::from_degrees(value.value),
-            WasmAngleUnit::Radians => Self::from_radians(value.value),
-        }
-    }
-}
-
-impl From<Angle> for WasmAngle {
-    fn from(value: Angle) -> Self {
-        Self {
-            value: value.to_radians(),
-            unit: WasmAngleUnit::Radians,
-        }
-    }
-}
-
-impl From<WasmAngleKind> for AngleKind {
-    fn from(value: WasmAngleKind) -> Self {
-        match value {
-            WasmAngleKind::Parallel => Self::Parallel,
-            WasmAngleKind::Perpendicular => Self::Perpendicular,
-            WasmAngleKind::Other(angle) => Self::Other(angle.into()),
-        }
-    }
-}
-
-impl From<WarningContent> for WasmWarningContent {
-    fn from(value: WarningContent) -> Self {
-        match value {
-            WarningContent::Degenerate => Self::Degenerate,
-            WarningContent::ShouldBeParallel(angle) => Self::ShouldBeParallel(angle.into()),
-            WarningContent::ShouldBePerpendicular(angle) => {
-                Self::ShouldBePerpendicular(angle.into())
-            }
-            _ => unreachable!("unsupported future WarningContent variant"),
-        }
-    }
-}
-
-impl From<Warning> for WasmWarning {
-    fn from(value: Warning) -> Self {
-        Self {
-            about_constraint: value.about_constraint,
-            content: value.content.into(),
-            message: value.content.to_string(),
-        }
-    }
-}
-
-impl From<WasmDatumDistance> for DatumDistance {
-    fn from(value: WasmDatumDistance) -> Self {
-        Self::new(value.id)
-    }
-}
-
-impl From<WasmDatumPoint> for DatumPoint {
-    fn from(value: WasmDatumPoint) -> Self {
-        Self::new_xy(value.x_id, value.y_id)
-    }
-}
-
-impl From<WasmDatumLineSegment> for DatumLineSegment {
-    fn from(value: WasmDatumLineSegment) -> Self {
-        Self::new(value.p0.into(), value.p1.into())
-    }
-}
-
-impl From<WasmDatumCircle> for DatumCircle {
-    fn from(value: WasmDatumCircle) -> Self {
-        Self {
-            center: value.center.into(),
-            radius: value.radius.into(),
-        }
-    }
-}
-
-impl From<WasmDatumCircularArc> for DatumCircularArc {
-    fn from(value: WasmDatumCircularArc) -> Self {
-        Self {
-            center: value.center.into(),
-            start: value.start.into(),
-            end: value.end.into(),
-        }
-    }
-}
-
-impl From<WasmLineSide> for LineSide {
-    fn from(value: WasmLineSide) -> Self {
-        match value {
-            WasmLineSide::Undefined => Self::Undefined,
-            WasmLineSide::Left => Self::Left,
-            WasmLineSide::Right => Self::Right,
-        }
-    }
-}
-
-impl From<WasmCircleSide> for CircleSide {
-    fn from(value: WasmCircleSide) -> Self {
-        match value {
-            WasmCircleSide::Undefined => Self::Undefined,
-            WasmCircleSide::Exterior => Self::Exterior,
-            WasmCircleSide::Interior => Self::Interior,
-        }
-    }
-}
-
-impl From<WasmConstraint> for Constraint {
-    fn from(value: WasmConstraint) -> Self {
-        match value {
-            WasmConstraint::LineTangentToCircle(line, circle, side) => {
-                Self::LineTangentToCircle(line.into(), circle.into(), side.into())
-            }
-            WasmConstraint::CircleTangentToCircle(circle0, circle1, side) => {
-                Self::CircleTangentToCircle(circle0.into(), circle1.into(), side.into())
-            }
-            WasmConstraint::Distance(p0, p1, distance) => {
-                Self::Distance(p0.into(), p1.into(), distance)
-            }
-            WasmConstraint::DistanceVar(p0, p1, distance) => {
-                Self::DistanceVar(p0.into(), p1.into(), distance.into())
-            }
-            WasmConstraint::VerticalDistance(p0, p1, distance) => {
-                Self::VerticalDistance(p0.into(), p1.into(), distance)
-            }
-            WasmConstraint::HorizontalDistance(p0, p1, distance) => {
-                Self::HorizontalDistance(p0.into(), p1.into(), distance)
-            }
-            WasmConstraint::Vertical(line) => Self::Vertical(line.into()),
-            WasmConstraint::Horizontal(line) => Self::Horizontal(line.into()),
-            WasmConstraint::LinesAtAngle(line0, line1, angle) => {
-                Self::LinesAtAngle(line0.into(), line1.into(), angle.into())
-            }
-            WasmConstraint::Fixed(id, value) => Self::Fixed(id, value),
-            WasmConstraint::ScalarEqual(left, right) => Self::ScalarEqual(left, right),
-            WasmConstraint::PointsCoincident(p0, p1) => {
-                Self::PointsCoincident(p0.into(), p1.into())
-            }
-            WasmConstraint::CircleRadius(circle, radius) => {
-                Self::CircleRadius(circle.into(), radius)
-            }
-            WasmConstraint::LinesEqualLength(line0, line1) => {
-                Self::LinesEqualLength(line0.into(), line1.into())
-            }
-            WasmConstraint::ArcRadius(arc, radius) => Self::ArcRadius(arc.into(), radius),
-            WasmConstraint::Arc(arc) => Self::Arc(arc.into()),
-            WasmConstraint::Midpoint(line, point) => Self::Midpoint(line.into(), point.into()),
-            WasmConstraint::PointLineDistance(point, line, distance) => {
-                Self::PointLineDistance(point.into(), line.into(), distance)
-            }
-            WasmConstraint::VerticalPointLineDistance(point, line, distance) => {
-                Self::VerticalPointLineDistance(point.into(), line.into(), distance)
-            }
-            WasmConstraint::HorizontalPointLineDistance(point, line, distance) => {
-                Self::HorizontalPointLineDistance(point.into(), line.into(), distance)
-            }
-            WasmConstraint::Symmetric(line, p0, p1) => {
-                Self::Symmetric(line.into(), p0.into(), p1.into())
-            }
-            WasmConstraint::PointArcCoincident(arc, point) => {
-                Self::PointArcCoincident(arc.into(), point.into())
-            }
-            WasmConstraint::ArcLength(arc, length) => Self::ArcLength(arc.into(), length),
-            WasmConstraint::ArcAngle(arc, angle) => Self::ArcAngle(arc.into(), angle.into()),
-            WasmConstraint::PointsAtAngle(p0, p1, p2, angle) => {
-                Self::PointsAtAngle(p0.into(), p1.into(), p2.into(), angle.into())
-            }
-        }
-    }
-}
-
-impl From<WasmConstraintRequest> for ConstraintRequest {
-    fn from(value: WasmConstraintRequest) -> Self {
-        ConstraintRequest::new(value.constraint.into(), value.priority).with_weight(value.weight)
-    }
-}
-
-impl From<Point> for WasmPoint {
-    fn from(value: Point) -> Self {
-        Self {
-            x: value.x,
-            y: value.y,
-        }
-    }
-}
-
-impl From<Circle> for WasmCircle {
-    fn from(value: Circle) -> Self {
-        Self {
-            radius: value.radius,
-            center: value.center.into(),
-        }
-    }
-}
-
-impl From<Arc> for WasmArc {
-    fn from(value: Arc) -> Self {
-        Self {
-            a: value.a.into(),
-            b: value.b.into(),
-            center: value.center.into(),
-        }
-    }
-}
-
-impl From<&FreedomAnalysis> for WasmFreedomAnalysis {
-    fn from(value: &FreedomAnalysis) -> Self {
-        Self {
-            underconstrained: value.underconstrained().to_vec(),
-            is_underconstrained: value.is_underconstrained(),
-        }
-    }
-}
-
-impl From<&SolveOutcome> for WasmSolveOutcome {
-    fn from(value: &SolveOutcome) -> Self {
-        Self {
-            unsatisfied: value.unsatisfied().to_vec(),
-            final_values: value.final_values().to_vec(),
-            iterations: value.iterations(),
-            warnings: value.warnings().iter().copied().map(Into::into).collect(),
-            priority_solved: value.priority_solved(),
-            is_satisfied: value.is_satisfied(),
-            is_unsatisfied: value.is_unsatisfied(),
-        }
-    }
-}
-
-impl From<&SolveOutcomeFreedomAnalysis> for WasmSolveOutcomeFreedomAnalysis {
-    fn from(value: &SolveOutcomeFreedomAnalysis) -> Self {
-        Self {
-            analysis: (&value.analysis).into(),
-            outcome: (&value.outcome).into(),
-        }
     }
 }
 
@@ -569,76 +131,9 @@ impl From<&FailureOutcome> for WasmFailureOutcome {
         Self {
             error: value.error().into(),
             message: value.error().to_string(),
-            warnings: value.warnings().iter().copied().map(Into::into).collect(),
+            warnings: value.warnings().to_vec(),
             num_vars: value.num_vars(),
             num_eqs: value.num_eqs(),
-        }
-    }
-}
-
-impl From<ezpz::TextualError> for WasmTextualError {
-    fn from(value: ezpz::TextualError) -> Self {
-        match value {
-            ezpz::TextualError::MissingGuess { label } => Self::MissingGuess { label },
-            ezpz::TextualError::UnusedGuesses { labels } => Self::UnusedGuesses { labels },
-            ezpz::TextualError::UndefinedPoint { label } => Self::UndefinedPoint { label },
-            _ => Self::Parse {
-                message: value.to_string(),
-            },
-        }
-    }
-}
-
-impl From<&textual::Outcome> for WasmTextualOutcome {
-    fn from(value: &textual::Outcome) -> Self {
-        Self {
-            unsatisfied: value.unsatisfied.clone(),
-            iterations: value.iterations,
-            warnings: value.warnings.iter().copied().map(Into::into).collect(),
-            points: value
-                .points
-                .iter()
-                .map(|(label, point)| WasmNamedPoint {
-                    label: label.clone(),
-                    point: (*point).into(),
-                })
-                .collect(),
-            circles: value
-                .circles
-                .iter()
-                .map(|(label, circle)| WasmNamedCircle {
-                    label: label.clone(),
-                    circle: (*circle).into(),
-                })
-                .collect(),
-            arcs: value
-                .arcs
-                .iter()
-                .map(|(label, arc)| WasmNamedArc {
-                    label: label.clone(),
-                    arc: (*arc).into(),
-                })
-                .collect(),
-            lines: value
-                .lines
-                .iter()
-                .map(|(p0, p1)| WasmNamedLine {
-                    p0: String::from(p0.clone()),
-                    p1: String::from(p1.clone()),
-                })
-                .collect(),
-            num_vars: value.num_vars,
-            num_eqs: value.num_eqs,
-            priority_solved: value.priority_solved,
-        }
-    }
-}
-
-impl From<&textual::OutcomeAnalysis> for WasmTextualOutcomeAnalysis {
-    fn from(value: &textual::OutcomeAnalysis) -> Self {
-        Self {
-            analysis: (&value.analysis).into(),
-            outcome: (&value.outcome).into(),
         }
     }
 }
@@ -648,8 +143,9 @@ fn failure_to_js(error: &FailureOutcome) -> JsValue {
         .unwrap_or_else(|_| JsValue::from_str(&error.error().to_string()))
 }
 
-fn textual_error_to_js(error: impl Into<WasmTextualError>) -> JsValue {
-    serialize(&error.into()).unwrap_or_else(|_| JsValue::from_str("textual error"))
+fn parse_string_error_to_js(message: String) -> JsValue {
+    serialize(&WasmStringError::Parse { message })
+        .unwrap_or_else(|_| JsValue::from_str("parse error"))
 }
 
 fn parse_config(config: Option<JsValue>) -> JsResult<Config> {
@@ -662,12 +158,19 @@ fn parse_config(config: Option<JsValue>) -> JsResult<Config> {
 }
 
 fn parse_requests(value: JsValue) -> JsResult<Vec<ConstraintRequest>> {
-    let requests: Vec<WasmConstraintRequest> = deserialize(value)?;
-    Ok(requests.into_iter().map(Into::into).collect())
+    deserialize(value)
 }
 
-fn parse_initial_guesses(value: JsValue) -> JsResult<Vec<(Id, f64)>> {
+fn parse_initial_guesses(value: JsValue) -> JsResult<Vec<(ezpz::Id, f64)>> {
     deserialize(value)
+}
+
+fn serialize_solve_outcome(outcome: &SolveOutcome) -> JsResult<JsValue> {
+    serialize(outcome)
+}
+
+fn serialize_solve_outcome_analysis(outcome: &SolveOutcomeFreedomAnalysis) -> JsResult<JsValue> {
+    serialize(outcome)
 }
 
 #[wasm_bindgen]
@@ -680,7 +183,7 @@ pub fn solve(
     let initial_guesses = parse_initial_guesses(initial_guesses)?;
     let config = parse_config(config)?;
     match ezpz::solve(&requests, initial_guesses, config) {
-        Ok(outcome) => serialize(&WasmSolveOutcome::from(&outcome)),
+        Ok(outcome) => serialize_solve_outcome(&outcome),
         Err(error) => Err(failure_to_js(&error)),
     }
 }
@@ -695,35 +198,33 @@ pub fn solve_analysis(
     let initial_guesses = parse_initial_guesses(initial_guesses)?;
     let config = parse_config(config)?;
     match ezpz::solve_analysis(&requests, initial_guesses, config) {
-        Ok(outcome) => serialize(&WasmSolveOutcomeFreedomAnalysis::from(&outcome)),
+        Ok(outcome) => serialize_solve_outcome_analysis(&outcome),
         Err(error) => Err(failure_to_js(&error)),
     }
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = solveText)]
 pub fn solve_text(source: &str, config: Option<JsValue>) -> JsResult<JsValue> {
-    let problem = textual::Problem::from_str(source)
-        .map_err(|message| textual_error_to_js(WasmTextualError::Parse { message }))?;
-    let system = problem
-        .to_constraint_system()
-        .map_err(textual_error_to_js)?;
+    let problem = textual::Problem::from_str(source).map_err(parse_string_error_to_js)?;
+    let system = problem.to_constraint_system().map_err(|error| {
+        serialize(&error).unwrap_or_else(|_| JsValue::from_str("textual error"))
+    })?;
     let config = parse_config(config)?;
     match system.solve_with_config(config) {
-        Ok(outcome) => serialize(&WasmTextualOutcome::from(&outcome)),
+        Ok(outcome) => serialize(&outcome),
         Err(error) => Err(failure_to_js(&error)),
     }
 }
 
 #[wasm_bindgen(js_name = solveTextAnalysis)]
 pub fn solve_text_analysis(source: &str, config: Option<JsValue>) -> JsResult<JsValue> {
-    let problem = textual::Problem::from_str(source)
-        .map_err(|message| textual_error_to_js(WasmTextualError::Parse { message }))?;
-    let system = problem
-        .to_constraint_system()
-        .map_err(textual_error_to_js)?;
+    let problem = textual::Problem::from_str(source).map_err(parse_string_error_to_js)?;
+    let system = problem.to_constraint_system().map_err(|error| {
+        serialize(&error).unwrap_or_else(|_| JsValue::from_str("textual error"))
+    })?;
     let config = parse_config(config)?;
     match system.solve_with_config_analysis(config) {
-        Ok(outcome) => serialize(&WasmTextualOutcomeAnalysis::from(&outcome)),
+        Ok(outcome) => serialize(&outcome),
         Err(error) => Err(failure_to_js(&error)),
     }
 }

--- a/ezpz-wasm/src/lib.rs
+++ b/ezpz-wasm/src/lib.rs
@@ -116,9 +116,6 @@ impl From<&NonLinearSystemError> for WasmNonLinearSystemError {
             },
             NonLinearSystemError::DidNotConverge => Self::DidNotConverge,
             NonLinearSystemError::EmptySystemNotAllowed => Self::EmptySystemNotAllowed,
-            _ => Self::Faer {
-                message: value.to_string(),
-            },
         }
     }
 }

--- a/ezpz-wasm/src/lib.rs
+++ b/ezpz-wasm/src/lib.rs
@@ -1,103 +1,729 @@
+use std::str::FromStr;
+
 use ezpz::{
-    Config, Constraint, ConstraintRequest, IdGenerator,
-    datatypes::inputs::{DatumLineSegment, DatumPoint},
-    solve,
+    CircleSide, Config, Constraint, ConstraintRequest, FailureOutcome, FreedomAnalysis, Id,
+    LineSide, NonLinearSystemError, SolveOutcome, SolveOutcomeFreedomAnalysis, Warning,
+    WarningContent,
+    datatypes::{Angle, AngleKind, inputs::*, outputs::*},
+    textual,
 };
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-pub fn hello() -> i32 {
-    33
+type JsResult<T> = Result<T, JsValue>;
+
+#[derive(Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmConfig {
+    max_iterations: Option<usize>,
+    convergence_tolerance: Option<f64>,
+    step_tolerance: Option<f64>,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum WasmAngleUnit {
+    Degrees,
+    Radians,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmAngle {
+    value: f64,
+    unit: WasmAngleUnit,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmDatumDistance {
+    id: Id,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmDatumPoint {
+    x_id: Id,
+    y_id: Id,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmDatumLineSegment {
+    p0: WasmDatumPoint,
+    p1: WasmDatumPoint,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmDatumCircle {
+    center: WasmDatumPoint,
+    radius: WasmDatumDistance,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmDatumCircularArc {
+    center: WasmDatumPoint,
+    start: WasmDatumPoint,
+    end: WasmDatumPoint,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum WasmAngleKind {
+    Parallel,
+    Perpendicular,
+    Other(WasmAngle),
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+enum WasmLineSide {
+    Undefined,
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+enum WasmCircleSide {
+    Undefined,
+    Exterior,
+    Interior,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data")]
+enum WasmConstraint {
+    LineTangentToCircle(WasmDatumLineSegment, WasmDatumCircle, WasmLineSide),
+    CircleTangentToCircle(WasmDatumCircle, WasmDatumCircle, WasmCircleSide),
+    Distance(WasmDatumPoint, WasmDatumPoint, f64),
+    DistanceVar(WasmDatumPoint, WasmDatumPoint, WasmDatumDistance),
+    VerticalDistance(WasmDatumPoint, WasmDatumPoint, f64),
+    HorizontalDistance(WasmDatumPoint, WasmDatumPoint, f64),
+    Vertical(WasmDatumLineSegment),
+    Horizontal(WasmDatumLineSegment),
+    LinesAtAngle(WasmDatumLineSegment, WasmDatumLineSegment, WasmAngleKind),
+    Fixed(Id, f64),
+    ScalarEqual(Id, Id),
+    PointsCoincident(WasmDatumPoint, WasmDatumPoint),
+    CircleRadius(WasmDatumCircle, f64),
+    LinesEqualLength(WasmDatumLineSegment, WasmDatumLineSegment),
+    ArcRadius(WasmDatumCircularArc, f64),
+    Arc(WasmDatumCircularArc),
+    Midpoint(WasmDatumLineSegment, WasmDatumPoint),
+    PointLineDistance(WasmDatumPoint, WasmDatumLineSegment, f64),
+    VerticalPointLineDistance(WasmDatumPoint, WasmDatumLineSegment, f64),
+    HorizontalPointLineDistance(WasmDatumPoint, WasmDatumLineSegment, f64),
+    Symmetric(WasmDatumLineSegment, WasmDatumPoint, WasmDatumPoint),
+    PointArcCoincident(WasmDatumCircularArc, WasmDatumPoint),
+    ArcLength(WasmDatumCircularArc, f64),
+    ArcAngle(WasmDatumCircularArc, WasmAngle),
+    PointsAtAngle(
+        WasmDatumPoint,
+        WasmDatumPoint,
+        WasmDatumPoint,
+        WasmAngleKind,
+    ),
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmConstraintRequest {
+    constraint: WasmConstraint,
+    priority: u32,
+    weight: f64,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmPoint {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmCircle {
+    radius: f64,
+    center: WasmPoint,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct WasmArc {
+    a: WasmPoint,
+    b: WasmPoint,
+    center: WasmPoint,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data")]
+enum WasmWarningContent {
+    Degenerate,
+    ShouldBeParallel(WasmAngle),
+    ShouldBePerpendicular(WasmAngle),
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmWarning {
+    about_constraint: Option<usize>,
+    content: WasmWarningContent,
+    message: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmSolveOutcome {
+    unsatisfied: Vec<usize>,
+    final_values: Vec<f64>,
+    iterations: usize,
+    warnings: Vec<WasmWarning>,
+    priority_solved: u32,
+    is_satisfied: bool,
+    is_unsatisfied: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmFreedomAnalysis {
+    underconstrained: Vec<Id>,
+    is_underconstrained: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmSolveOutcomeFreedomAnalysis {
+    analysis: WasmFreedomAnalysis,
+    outcome: WasmSolveOutcome,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data")]
+enum WasmNonLinearSystemError {
+    NotFound(Id),
+    WrongNumberGuesses { labels: usize, guesses: usize },
+    MissingGuess { constraint_id: usize, variable: Id },
+    FaerMatrix { message: String },
+    Faer { message: String },
+    FaerSolve { message: String },
+    FaerSvd { message: String },
+    DidNotConverge,
+    EmptySystemNotAllowed,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmFailureOutcome {
+    error: WasmNonLinearSystemError,
+    message: String,
+    warnings: Vec<WasmWarning>,
+    num_vars: usize,
+    num_eqs: usize,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data")]
+enum WasmTextualError {
+    MissingGuess { label: String },
+    UnusedGuesses { labels: Vec<String> },
+    UndefinedPoint { label: String },
+    Parse { message: String },
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmNamedPoint {
+    label: String,
+    point: WasmPoint,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmNamedCircle {
+    label: String,
+    circle: WasmCircle,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmNamedArc {
+    label: String,
+    arc: WasmArc,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmNamedLine {
+    p0: String,
+    p1: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmTextualOutcome {
+    unsatisfied: Vec<usize>,
+    iterations: usize,
+    warnings: Vec<WasmWarning>,
+    points: Vec<WasmNamedPoint>,
+    circles: Vec<WasmNamedCircle>,
+    arcs: Vec<WasmNamedArc>,
+    lines: Vec<WasmNamedLine>,
+    num_vars: usize,
+    num_eqs: usize,
+    priority_solved: u32,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WasmTextualOutcomeAnalysis {
+    analysis: WasmFreedomAnalysis,
+    outcome: WasmTextualOutcome,
+}
+
+fn serialize<T: Serialize>(value: &T) -> JsResult<JsValue> {
+    serde_wasm_bindgen::to_value(value).map_err(js_value_from_display)
+}
+
+fn deserialize<T: DeserializeOwned>(value: JsValue) -> JsResult<T> {
+    serde_wasm_bindgen::from_value(value).map_err(js_value_from_display)
+}
+
+fn js_value_from_display(error: impl std::fmt::Display) -> JsValue {
+    JsValue::from_str(&error.to_string())
+}
+
+impl From<WasmConfig> for Config {
+    fn from(value: WasmConfig) -> Self {
+        let mut out = Config::default();
+        if let Some(max_iterations) = value.max_iterations {
+            out = out.with_max_iterations(max_iterations);
+        }
+        if let Some(convergence_tolerance) = value.convergence_tolerance {
+            out = out.with_convergence_tolerance(convergence_tolerance);
+        }
+        if let Some(step_tolerance) = value.step_tolerance {
+            out = out.with_step_tolerance(step_tolerance);
+        }
+        out
+    }
+}
+
+impl From<WasmAngle> for Angle {
+    fn from(value: WasmAngle) -> Self {
+        match value.unit {
+            WasmAngleUnit::Degrees => Self::from_degrees(value.value),
+            WasmAngleUnit::Radians => Self::from_radians(value.value),
+        }
+    }
+}
+
+impl From<Angle> for WasmAngle {
+    fn from(value: Angle) -> Self {
+        Self {
+            value: value.to_radians(),
+            unit: WasmAngleUnit::Radians,
+        }
+    }
+}
+
+impl From<WasmAngleKind> for AngleKind {
+    fn from(value: WasmAngleKind) -> Self {
+        match value {
+            WasmAngleKind::Parallel => Self::Parallel,
+            WasmAngleKind::Perpendicular => Self::Perpendicular,
+            WasmAngleKind::Other(angle) => Self::Other(angle.into()),
+        }
+    }
+}
+
+impl From<WarningContent> for WasmWarningContent {
+    fn from(value: WarningContent) -> Self {
+        match value {
+            WarningContent::Degenerate => Self::Degenerate,
+            WarningContent::ShouldBeParallel(angle) => Self::ShouldBeParallel(angle.into()),
+            WarningContent::ShouldBePerpendicular(angle) => {
+                Self::ShouldBePerpendicular(angle.into())
+            }
+            _ => unreachable!("unsupported future WarningContent variant"),
+        }
+    }
+}
+
+impl From<Warning> for WasmWarning {
+    fn from(value: Warning) -> Self {
+        Self {
+            about_constraint: value.about_constraint,
+            content: value.content.into(),
+            message: value.content.to_string(),
+        }
+    }
+}
+
+impl From<WasmDatumDistance> for DatumDistance {
+    fn from(value: WasmDatumDistance) -> Self {
+        Self::new(value.id)
+    }
+}
+
+impl From<WasmDatumPoint> for DatumPoint {
+    fn from(value: WasmDatumPoint) -> Self {
+        Self::new_xy(value.x_id, value.y_id)
+    }
+}
+
+impl From<WasmDatumLineSegment> for DatumLineSegment {
+    fn from(value: WasmDatumLineSegment) -> Self {
+        Self::new(value.p0.into(), value.p1.into())
+    }
+}
+
+impl From<WasmDatumCircle> for DatumCircle {
+    fn from(value: WasmDatumCircle) -> Self {
+        Self {
+            center: value.center.into(),
+            radius: value.radius.into(),
+        }
+    }
+}
+
+impl From<WasmDatumCircularArc> for DatumCircularArc {
+    fn from(value: WasmDatumCircularArc) -> Self {
+        Self {
+            center: value.center.into(),
+            start: value.start.into(),
+            end: value.end.into(),
+        }
+    }
+}
+
+impl From<WasmLineSide> for LineSide {
+    fn from(value: WasmLineSide) -> Self {
+        match value {
+            WasmLineSide::Undefined => Self::Undefined,
+            WasmLineSide::Left => Self::Left,
+            WasmLineSide::Right => Self::Right,
+        }
+    }
+}
+
+impl From<WasmCircleSide> for CircleSide {
+    fn from(value: WasmCircleSide) -> Self {
+        match value {
+            WasmCircleSide::Undefined => Self::Undefined,
+            WasmCircleSide::Exterior => Self::Exterior,
+            WasmCircleSide::Interior => Self::Interior,
+        }
+    }
+}
+
+impl From<WasmConstraint> for Constraint {
+    fn from(value: WasmConstraint) -> Self {
+        match value {
+            WasmConstraint::LineTangentToCircle(line, circle, side) => {
+                Self::LineTangentToCircle(line.into(), circle.into(), side.into())
+            }
+            WasmConstraint::CircleTangentToCircle(circle0, circle1, side) => {
+                Self::CircleTangentToCircle(circle0.into(), circle1.into(), side.into())
+            }
+            WasmConstraint::Distance(p0, p1, distance) => {
+                Self::Distance(p0.into(), p1.into(), distance)
+            }
+            WasmConstraint::DistanceVar(p0, p1, distance) => {
+                Self::DistanceVar(p0.into(), p1.into(), distance.into())
+            }
+            WasmConstraint::VerticalDistance(p0, p1, distance) => {
+                Self::VerticalDistance(p0.into(), p1.into(), distance)
+            }
+            WasmConstraint::HorizontalDistance(p0, p1, distance) => {
+                Self::HorizontalDistance(p0.into(), p1.into(), distance)
+            }
+            WasmConstraint::Vertical(line) => Self::Vertical(line.into()),
+            WasmConstraint::Horizontal(line) => Self::Horizontal(line.into()),
+            WasmConstraint::LinesAtAngle(line0, line1, angle) => {
+                Self::LinesAtAngle(line0.into(), line1.into(), angle.into())
+            }
+            WasmConstraint::Fixed(id, value) => Self::Fixed(id, value),
+            WasmConstraint::ScalarEqual(left, right) => Self::ScalarEqual(left, right),
+            WasmConstraint::PointsCoincident(p0, p1) => {
+                Self::PointsCoincident(p0.into(), p1.into())
+            }
+            WasmConstraint::CircleRadius(circle, radius) => {
+                Self::CircleRadius(circle.into(), radius)
+            }
+            WasmConstraint::LinesEqualLength(line0, line1) => {
+                Self::LinesEqualLength(line0.into(), line1.into())
+            }
+            WasmConstraint::ArcRadius(arc, radius) => Self::ArcRadius(arc.into(), radius),
+            WasmConstraint::Arc(arc) => Self::Arc(arc.into()),
+            WasmConstraint::Midpoint(line, point) => Self::Midpoint(line.into(), point.into()),
+            WasmConstraint::PointLineDistance(point, line, distance) => {
+                Self::PointLineDistance(point.into(), line.into(), distance)
+            }
+            WasmConstraint::VerticalPointLineDistance(point, line, distance) => {
+                Self::VerticalPointLineDistance(point.into(), line.into(), distance)
+            }
+            WasmConstraint::HorizontalPointLineDistance(point, line, distance) => {
+                Self::HorizontalPointLineDistance(point.into(), line.into(), distance)
+            }
+            WasmConstraint::Symmetric(line, p0, p1) => {
+                Self::Symmetric(line.into(), p0.into(), p1.into())
+            }
+            WasmConstraint::PointArcCoincident(arc, point) => {
+                Self::PointArcCoincident(arc.into(), point.into())
+            }
+            WasmConstraint::ArcLength(arc, length) => Self::ArcLength(arc.into(), length),
+            WasmConstraint::ArcAngle(arc, angle) => Self::ArcAngle(arc.into(), angle.into()),
+            WasmConstraint::PointsAtAngle(p0, p1, p2, angle) => {
+                Self::PointsAtAngle(p0.into(), p1.into(), p2.into(), angle.into())
+            }
+        }
+    }
+}
+
+impl From<WasmConstraintRequest> for ConstraintRequest {
+    fn from(value: WasmConstraintRequest) -> Self {
+        ConstraintRequest::new(value.constraint.into(), value.priority).with_weight(value.weight)
+    }
+}
+
+impl From<Point> for WasmPoint {
+    fn from(value: Point) -> Self {
+        Self {
+            x: value.x,
+            y: value.y,
+        }
+    }
+}
+
+impl From<Circle> for WasmCircle {
+    fn from(value: Circle) -> Self {
+        Self {
+            radius: value.radius,
+            center: value.center.into(),
+        }
+    }
+}
+
+impl From<Arc> for WasmArc {
+    fn from(value: Arc) -> Self {
+        Self {
+            a: value.a.into(),
+            b: value.b.into(),
+            center: value.center.into(),
+        }
+    }
+}
+
+impl From<&FreedomAnalysis> for WasmFreedomAnalysis {
+    fn from(value: &FreedomAnalysis) -> Self {
+        Self {
+            underconstrained: value.underconstrained().to_vec(),
+            is_underconstrained: value.is_underconstrained(),
+        }
+    }
+}
+
+impl From<&SolveOutcome> for WasmSolveOutcome {
+    fn from(value: &SolveOutcome) -> Self {
+        Self {
+            unsatisfied: value.unsatisfied().to_vec(),
+            final_values: value.final_values().to_vec(),
+            iterations: value.iterations(),
+            warnings: value.warnings().iter().copied().map(Into::into).collect(),
+            priority_solved: value.priority_solved(),
+            is_satisfied: value.is_satisfied(),
+            is_unsatisfied: value.is_unsatisfied(),
+        }
+    }
+}
+
+impl From<&SolveOutcomeFreedomAnalysis> for WasmSolveOutcomeFreedomAnalysis {
+    fn from(value: &SolveOutcomeFreedomAnalysis) -> Self {
+        Self {
+            analysis: (&value.analysis).into(),
+            outcome: (&value.outcome).into(),
+        }
+    }
+}
+
+impl From<&NonLinearSystemError> for WasmNonLinearSystemError {
+    fn from(value: &NonLinearSystemError) -> Self {
+        match value {
+            NonLinearSystemError::NotFound(id) => Self::NotFound(*id),
+            NonLinearSystemError::WrongNumberGuesses { labels, guesses } => {
+                Self::WrongNumberGuesses {
+                    labels: *labels,
+                    guesses: *guesses,
+                }
+            }
+            NonLinearSystemError::MissingGuess {
+                constraint_id,
+                variable,
+            } => Self::MissingGuess {
+                constraint_id: *constraint_id,
+                variable: *variable,
+            },
+            NonLinearSystemError::FaerMatrix { error } => Self::FaerMatrix {
+                message: error.to_string(),
+            },
+            NonLinearSystemError::Faer { error } => Self::Faer {
+                message: error.to_string(),
+            },
+            NonLinearSystemError::FaerSolve { error } => Self::FaerSolve {
+                message: error.to_string(),
+            },
+            NonLinearSystemError::FaerSvd(error) => Self::FaerSvd {
+                message: format!("{error:?}"),
+            },
+            NonLinearSystemError::DidNotConverge => Self::DidNotConverge,
+            NonLinearSystemError::EmptySystemNotAllowed => Self::EmptySystemNotAllowed,
+            _ => Self::Faer {
+                message: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<&FailureOutcome> for WasmFailureOutcome {
+    fn from(value: &FailureOutcome) -> Self {
+        Self {
+            error: value.error().into(),
+            message: value.error().to_string(),
+            warnings: value.warnings().iter().copied().map(Into::into).collect(),
+            num_vars: value.num_vars(),
+            num_eqs: value.num_eqs(),
+        }
+    }
+}
+
+impl From<ezpz::TextualError> for WasmTextualError {
+    fn from(value: ezpz::TextualError) -> Self {
+        match value {
+            ezpz::TextualError::MissingGuess { label } => Self::MissingGuess { label },
+            ezpz::TextualError::UnusedGuesses { labels } => Self::UnusedGuesses { labels },
+            ezpz::TextualError::UndefinedPoint { label } => Self::UndefinedPoint { label },
+            _ => Self::Parse {
+                message: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<&textual::Outcome> for WasmTextualOutcome {
+    fn from(value: &textual::Outcome) -> Self {
+        Self {
+            unsatisfied: value.unsatisfied.clone(),
+            iterations: value.iterations,
+            warnings: value.warnings.iter().copied().map(Into::into).collect(),
+            points: value
+                .points
+                .iter()
+                .map(|(label, point)| WasmNamedPoint {
+                    label: label.clone(),
+                    point: (*point).into(),
+                })
+                .collect(),
+            circles: value
+                .circles
+                .iter()
+                .map(|(label, circle)| WasmNamedCircle {
+                    label: label.clone(),
+                    circle: (*circle).into(),
+                })
+                .collect(),
+            arcs: value
+                .arcs
+                .iter()
+                .map(|(label, arc)| WasmNamedArc {
+                    label: label.clone(),
+                    arc: (*arc).into(),
+                })
+                .collect(),
+            lines: value
+                .lines
+                .iter()
+                .map(|(p0, p1)| WasmNamedLine {
+                    p0: String::from(p0.clone()),
+                    p1: String::from(p1.clone()),
+                })
+                .collect(),
+            num_vars: value.num_vars,
+            num_eqs: value.num_eqs,
+            priority_solved: value.priority_solved,
+        }
+    }
+}
+
+impl From<&textual::OutcomeAnalysis> for WasmTextualOutcomeAnalysis {
+    fn from(value: &textual::OutcomeAnalysis) -> Self {
+        Self {
+            analysis: (&value.analysis).into(),
+            outcome: (&value.outcome).into(),
+        }
+    }
+}
+
+fn failure_to_js(error: &FailureOutcome) -> JsValue {
+    serialize(&WasmFailureOutcome::from(error))
+        .unwrap_or_else(|_| JsValue::from_str(&error.error().to_string()))
+}
+
+fn textual_error_to_js(error: impl Into<WasmTextualError>) -> JsValue {
+    serialize(&error.into()).unwrap_or_else(|_| JsValue::from_str("textual error"))
+}
+
+fn parse_config(config: Option<JsValue>) -> JsResult<Config> {
+    match config {
+        Some(config) if !config.is_undefined() && !config.is_null() => {
+            Ok(Config::from(deserialize::<WasmConfig>(config)?))
+        }
+        _ => Ok(Config::default()),
+    }
+}
+
+fn parse_requests(value: JsValue) -> JsResult<Vec<ConstraintRequest>> {
+    let requests: Vec<WasmConstraintRequest> = deserialize(value)?;
+    Ok(requests.into_iter().map(Into::into).collect())
+}
+
+fn parse_initial_guesses(value: JsValue) -> JsResult<Vec<(Id, f64)>> {
+    deserialize(value)
 }
 
 #[wasm_bindgen]
-pub fn test_faer() -> f64 {
-    use faer::mat;
+pub fn solve(
+    requests: JsValue,
+    initial_guesses: JsValue,
+    config: Option<JsValue>,
+) -> JsResult<JsValue> {
+    let requests = parse_requests(requests)?;
+    let initial_guesses = parse_initial_guesses(initial_guesses)?;
+    let config = parse_config(config)?;
+    match ezpz::solve(&requests, initial_guesses, config) {
+        Ok(outcome) => serialize(&WasmSolveOutcome::from(&outcome)),
+        Err(error) => Err(failure_to_js(&error)),
+    }
+}
 
-    let a = mat![
-        [1.0, 5.0, 9.0], //
-        [2.0, 6.0, 10.0],
-        [3.0, 7.0, 11.0],
-        [4.0, 8.0, 12.0f64],
-    ];
-
-    a[(0, 0)]
+#[wasm_bindgen(js_name = solveAnalysis)]
+pub fn solve_analysis(
+    requests: JsValue,
+    initial_guesses: JsValue,
+    config: Option<JsValue>,
+) -> JsResult<JsValue> {
+    let requests = parse_requests(requests)?;
+    let initial_guesses = parse_initial_guesses(initial_guesses)?;
+    let config = parse_config(config)?;
+    match ezpz::solve_analysis(&requests, initial_guesses, config) {
+        Ok(outcome) => serialize(&WasmSolveOutcomeFreedomAnalysis::from(&outcome)),
+        Err(error) => Err(failure_to_js(&error)),
+    }
 }
 
 #[wasm_bindgen]
-pub fn benchmark() -> Vec<f64> {
-    let mut id_generator = IdGenerator::default();
-    let p0 = DatumPoint::new(&mut id_generator);
-    let p1 = DatumPoint::new(&mut id_generator);
-    let p2 = DatumPoint::new(&mut id_generator);
-    let p3 = DatumPoint::new(&mut id_generator);
-    let line0_bottom = DatumLineSegment::new(p0, p1);
-    let line0_right = DatumLineSegment::new(p1, p2);
-    let line0_top = DatumLineSegment::new(p2, p3);
-    let line0_left = DatumLineSegment::new(p3, p0);
-    // Second square (upper case IDs)
-    let p5 = DatumPoint::new(&mut id_generator);
-    let p6 = DatumPoint::new(&mut id_generator);
-    let p7 = DatumPoint::new(&mut id_generator);
-    let line1_bottom = DatumLineSegment::new(p2, p5);
-    let line1_right = DatumLineSegment::new(p5, p6);
-    let line1_top = DatumLineSegment::new(p6, p7);
-    let line1_left = DatumLineSegment::new(p7, p2);
-    // First square (lower case IDs)
-    let constraints0 = vec![
-        Constraint::Fixed(p0.id_x(), 1.0),
-        Constraint::Fixed(p0.id_y(), 1.0),
-        Constraint::Horizontal(line0_bottom),
-        Constraint::Horizontal(line0_top),
-        Constraint::Vertical(line0_left),
-        Constraint::Vertical(line0_right),
-        Constraint::Distance(p0, p1, 4.0),
-        Constraint::Distance(p0, p3, 3.0),
-    ];
+pub fn solve_text(source: &str, config: Option<JsValue>) -> JsResult<JsValue> {
+    let problem = textual::Problem::from_str(source)
+        .map_err(|message| textual_error_to_js(WasmTextualError::Parse { message }))?;
+    let system = problem
+        .to_constraint_system()
+        .map_err(textual_error_to_js)?;
+    let config = parse_config(config)?;
+    match system.solve_with_config(config) {
+        Ok(outcome) => serialize(&WasmTextualOutcome::from(&outcome)),
+        Err(error) => Err(failure_to_js(&error)),
+    }
+}
 
-    // Start p at the origin, and q at (1,9)
-    let initial_guesses = vec![
-        // First square.
-        (p0.id_x(), 1.0),
-        (p0.id_y(), 1.0),
-        (p1.id_x(), 4.5),
-        (p1.id_y(), 1.5),
-        (p2.id_x(), 4.0),
-        (p2.id_y(), 3.5),
-        (p3.id_x(), 1.5),
-        (p3.id_y(), 3.0),
-        // Second square.
-        (p5.id_x(), 5.5),
-        (p5.id_y(), 3.5),
-        (p6.id_x(), 5.0),
-        (p6.id_y(), 4.5),
-        (p7.id_x(), 2.5),
-        (p7.id_y(), 4.0),
-    ];
-
-    let constraints1 = vec![
-        Constraint::Horizontal(line1_bottom),
-        Constraint::Horizontal(line1_top),
-        Constraint::Vertical(line1_left),
-        Constraint::Vertical(line1_right),
-        Constraint::Distance(p2, p5, 4.0),
-        Constraint::Distance(p2, p7, 4.0),
-    ];
-
-    let mut constraints: Vec<_> = constraints0
-        .into_iter()
-        .map(ConstraintRequest::highest_priority)
-        .collect();
-    constraints.extend(
-        constraints1
-            .into_iter()
-            .map(ConstraintRequest::highest_priority),
-    );
-    let actual = solve(
-        &constraints.clone(),
-        initial_guesses.clone(),
-        Config::default(),
-    )
-    .unwrap();
-    actual.final_values().to_owned()
+#[wasm_bindgen(js_name = solveTextAnalysis)]
+pub fn solve_text_analysis(source: &str, config: Option<JsValue>) -> JsResult<JsValue> {
+    let problem = textual::Problem::from_str(source)
+        .map_err(|message| textual_error_to_js(WasmTextualError::Parse { message }))?;
+    let system = problem
+        .to_constraint_system()
+        .map_err(textual_error_to_js)?;
+    let config = parse_config(config)?;
+    match system.solve_with_config_analysis(config) {
+        Ok(outcome) => serialize(&WasmTextualOutcomeAnalysis::from(&outcome)),
+        Err(error) => Err(failure_to_js(&error)),
+    }
 }

--- a/ezpz/Cargo.toml
+++ b/ezpz/Cargo.toml
@@ -21,9 +21,10 @@ unstable-exhaustive = []
 image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
 arbitrary = { version = "1.4.2", features = ["derive"], optional = true }
 faer = { version = "0.24.0", default-features = false, features = ["std", "sparse-linalg"] }
-indexmap = "2.11.0"
+indexmap = { version = "2.11.0", features = ["serde"] }
 libm = "0.2.15"
 mutants = "0.0.3"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0.14"
 winnow = { version = "1.0" }
 

--- a/ezpz/src/analysis.rs
+++ b/ezpz/src/analysis.rs
@@ -1,4 +1,5 @@
 use crate::{NonLinearSystemError, SolveOutcomeFreedomAnalysis, solver::Model};
+use serde::{Deserialize, Serialize};
 
 pub(crate) trait Analysis: Sized {
     fn analyze(model: Model<'_>) -> Result<Self, NonLinearSystemError>;
@@ -22,7 +23,7 @@ impl Analysis for NoAnalysis {
 
 /// Results from analyzing the freedom of each variable.
 /// Created from [`crate::solve_analysis`].
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 pub struct FreedomAnalysis {
     /// These variables are underconstrained, and the user could (probably should)

--- a/ezpz/src/constraint_request.rs
+++ b/ezpz/src/constraint_request.rs
@@ -1,4 +1,5 @@
 use crate::Constraint;
+use serde::{Deserialize, Serialize};
 
 /// A constraint that EZPZ should solve for.
 /// ```
@@ -8,7 +9,7 @@ use crate::Constraint;
 /// let priority = 3;
 /// let constraint_req = ConstraintRequest::new(constraint, priority);
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ConstraintRequest {
     /// The constraint itself.

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -5,6 +5,7 @@ use crate::{
     solver::Layout,
     vector::{Rotation2, V},
 };
+use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
 
 /// Constructors for constraints which are a composition of
@@ -31,7 +32,7 @@ impl AsRef<Constraint> for ConstraintEntry<'_> {
 }
 
 /// Each geometric constraint we support.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 pub enum Constraint {
@@ -102,7 +103,7 @@ pub(crate) struct JacobianVar {
     pub partial_derivative: f64,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 /// Which side of a directed line a constraint refers to.
@@ -115,7 +116,7 @@ pub enum LineSide {
     Right,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 /// Which side of a circle a constraint refers to.

--- a/ezpz/src/datatypes.rs
+++ b/ezpz/src/datatypes.rs
@@ -1,9 +1,11 @@
 pub mod inputs;
 pub mod outputs;
 
+use serde::{Deserialize, Serialize};
+
 /// Possible angles, with specific descriptors for special angles
 /// like parallel or perpendicular.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 pub enum AngleKind {
@@ -16,7 +18,7 @@ pub enum AngleKind {
 }
 
 /// A measurement of a particular angle, could be degrees or radians.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Angle {

--- a/ezpz/src/datatypes/inputs.rs
+++ b/ezpz/src/datatypes/inputs.rs
@@ -1,5 +1,7 @@
 //! Geometric entities that can be constrained and solved by ezpz.
 
+use serde::{Deserialize, Serialize};
+
 use crate::{Id, IdGenerator};
 
 pub(crate) trait Datum {
@@ -14,7 +16,7 @@ pub(crate) trait Datum {
 /// let mut ids = IdGenerator::default();
 /// let dist = DatumDistance::new(ids.next_id());
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct DatumDistance {
     /// ID of the variable for this distance.
@@ -49,7 +51,7 @@ impl Datum for DatumDistance {
 /// let mut ids = IdGenerator::default();
 /// let p = DatumPoint::new(&mut ids);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct DatumPoint {
     /// ID of the variable for this point's X component.
@@ -109,7 +111,7 @@ impl Datum for DatumPoint {
 /// Finite segment of a line.
 /// It has two points, one at each end, and those points
 /// can be determined by the constraint solver.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct DatumLineSegment {
     /// Point for one end of this line.
@@ -146,7 +148,7 @@ impl Datum for DatumLineSegment {
 }
 
 /// A circle, whose radius and position can be determined by the constraint solver.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct DatumCircle {
     /// Center of the circle.
@@ -166,7 +168,7 @@ impl Datum for DatumCircle {
 /// The arc's start, end and center can be determined by the constraint solver.
 /// The arc always goes counter-clockwise from start to end.
 /// To get a clockwise arc, swap start and end.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct DatumCircularArc {
     /// Center of the circle

--- a/ezpz/src/datatypes/outputs.rs
+++ b/ezpz/src/datatypes/outputs.rs
@@ -1,7 +1,9 @@
 //! The final solved values of various geometry.
 
+use serde::{Deserialize, Serialize};
+
 /// A 2D point that ezpz solved for, i.e. found values for all its variables.
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct Point {
     #[allow(missing_docs)]
     pub x: f64,
@@ -24,7 +26,7 @@ impl From<Point> for (f64, f64) {
 }
 
 /// A 2D circle that ezpz solved for, i.e. found values for all its variables.
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct Circle {
     /// Radius of the circle.
     pub radius: f64,
@@ -33,7 +35,7 @@ pub struct Circle {
 }
 
 /// A 2D circular arc that ezpz solved for, i.e. found values for all its variables.
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct Arc {
     /// A point at one end of the arc.
     /// This doesn't specifically mean the start or end or anything.
@@ -60,7 +62,7 @@ impl Point {
 }
 
 /// Component of a 2D point.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Component {
     /// Horizontal (X) component.
     X,

--- a/ezpz/src/error.rs
+++ b/ezpz/src/error.rs
@@ -2,11 +2,12 @@ use faer::{
     linalg::svd::SvdError,
     sparse::{CreationError, FaerError, linalg::LuError},
 };
+use serde::{Deserialize, Serialize};
 
 use crate::Id;
 
 /// Errors from parsing and executing ezpz's textual representation.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 pub enum TextualError {
     /// No initial guess was given for this label.

--- a/ezpz/src/solve_outcome.rs
+++ b/ezpz/src/solve_outcome.rs
@@ -5,9 +5,10 @@ use crate::{
         outputs::{Arc, Circle, Point},
     },
 };
+use serde::{Deserialize, Serialize};
 
 /// Data from a successful solved system.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 pub struct SolveOutcome {
     /// Which constraints couldn't be satisfied
@@ -98,7 +99,7 @@ impl SolveOutcome {
 /// Created from [`crate::solve_analysis`].
 // This is just like `SolveOutcomeAnalysis<FreedomAnalysis>`,
 // except it doesn't leak the private trait `Analysis`.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SolveOutcomeFreedomAnalysis {
     /// Extra analysis for the system,
     /// which is probably expensive to compute.

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 
 use faer::sparse::{Pair, SparseColMatRef, SymbolicSparseColMat, linalg::solvers::SymbolicLu};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     Constraint, ConstraintEntry, NonLinearSystemError, Warning, WarningContent,
@@ -25,7 +26,7 @@ const REGULARIZATION_LAMBDA: f64 = 1e-9;
 ///     .with_max_iterations(200)
 ///     .with_convergence_tolerance(1e-10);
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Config {
     /// How many iteration rounds before the solver gives up?

--- a/ezpz/src/textual.rs
+++ b/ezpz/src/textual.rs
@@ -3,6 +3,7 @@ mod geometry_variables;
 mod instruction;
 mod parser;
 
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 pub use executor::ConstraintSystem;
@@ -50,7 +51,7 @@ impl FromStr for Problem {
 
 /// The label of a variable being solved for in the system.
 /// E.g. `p.x` or `p.y` or `arc.center`.
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct Label(String);
 
 impl From<&str> for Label {

--- a/ezpz/src/textual/executor.rs
+++ b/ezpz/src/textual/executor.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 
 use crate::Analysis;
 use crate::Config;
@@ -582,7 +583,7 @@ impl ConstraintSystem<'_> {
 }
 
 /// Outcome of successfully solving a constraint system.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Outcome {
     /// All constraint IDs which couldn't be satisfied.
     pub unsatisfied: Vec<usize>,
@@ -609,7 +610,7 @@ pub struct Outcome {
 }
 
 /// Outcome of solving an ezpz system, and degrees-of-freedom analysis.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OutcomeAnalysis {
     /// Degrees of freedom analysis
     pub analysis: FreedomAnalysis,

--- a/ezpz/src/warnings.rs
+++ b/ezpz/src/warnings.rs
@@ -3,9 +3,10 @@ use crate::{
     constraints::ConstraintEntry,
     datatypes::{Angle, AngleKind},
 };
+use serde::{Deserialize, Serialize};
 
 /// Something bad that users should know about.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Warning {
     /// If this warning is about a particular constraint, which constraint?
@@ -16,7 +17,7 @@ pub struct Warning {
 }
 
 /// What went wrong, or should be done differently.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(not(feature = "unstable-exhaustive"), non_exhaustive)]
 pub enum WarningContent {

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 clippy-flags := "--workspace --tests --benches --examples --all-targets"
 gen := "test_cases/massive_parallel_system/gen_big_problem.py"
+wasm-pack-flags := "--target web --scope kittycad"
 
 # Check most of CI, but locally.
 @check-most:
@@ -20,7 +21,11 @@ lint-fix:
 # Check our WASM projects build properly.
 check-wasm:
     cargo check -p ezpz-wasm --target wasm32-unknown-unknown
-    cd ezpz-wasm; wasm-pack build --target web --dev; cd -
+    cd ezpz-wasm; wasm-pack build {{wasm-pack-flags}} --dev; cd -
+
+# Build the published WASM package.
+build-wasm:
+    cd ezpz-wasm; wasm-pack build {{wasm-pack-flags}}; cd -
 
 test:
     cargo nextest run --all-features --release


### PR DESCRIPTION
This replaces the basic "how to build a custom wasm package" part of `ezpz-wasm`, with a full exposure of the library, with aim to make the abstraction as automatic and thin as possible, so the full power of `ezpz` can be realized in any web situation.

---

I'd like to consume this first before getting it merged