### PR TITLE
DidNotConverge should no longer be an error

### DIFF
--- a/ezpz-cli/src/main.rs
+++ b/ezpz-cli/src/main.rs
@@ -115,12 +115,18 @@ fn print_output((outcome, duration, constraints): &RunOutcome, show_points: bool
         lines: _, // these are only used for visuals
         unsatisfied,
         priority_solved,
+        converged,
     } = outcome;
     print_warnings(warnings);
     print_unsatisfied(unsatisfied, constraints);
     print_problem_size(*num_vars, *num_eqs);
     println!("Iterations needed: {iterations}");
     println!("Solved up to priority: {priority_solved}");
+    if !converged {
+        use colored::Colorize;
+        let error = "Error".to_string().red();
+        println!("{error}: solver did not converge!")
+    }
     print_performance(*duration);
     if show_points {
         println!("Points:");

--- a/ezpz/src/error.rs
+++ b/ezpz/src/error.rs
@@ -80,10 +80,6 @@ pub enum NonLinearSystemError {
     /// Faer: could not decompose Jacobian.
     #[error("Something went wrong doing SVD in faer")]
     FaerSvd(SvdError),
-    /// Solver did not find a solution within the allowed number of iterations.
-    /// Consider raising the iterations?
-    #[error("Could not find a solution in the allowed number of iterations")]
-    DidNotConverge,
     /// You provided an empty constraint system.
     #[error("Cannot solve an empty system")]
     EmptySystemNotAllowed,

--- a/ezpz/src/lib.rs
+++ b/ezpz/src/lib.rs
@@ -164,6 +164,7 @@ pub(crate) fn solve_with_priority_inner<A: Analysis>(
                 iterations: 0,
                 warnings: Vec::new(),
                 priority_solved: 0,
+                converged: true,
             },
         });
     }
@@ -256,6 +257,7 @@ pub(crate) fn solve_with_priority_inner<A: Analysis>(
             iterations: 0,
             warnings: Vec::new(),
             priority_solved: lowest_priority,
+            converged: true,
         },
     }))
 }
@@ -347,6 +349,7 @@ fn solve_inner<A: Analysis>(
             final_values: values,
             iterations: success.iterations,
             warnings,
+            converged: success.converged,
         },
         analysis,
     })

--- a/ezpz/src/solve_outcome.rs
+++ b/ezpz/src/solve_outcome.rs
@@ -12,6 +12,8 @@ use crate::{
 pub struct SolveOutcome {
     /// Which constraints couldn't be satisfied
     pub(crate) unsatisfied: Vec<usize>,
+    /// Did the solver converge on a solution?
+    pub(crate) converged: bool,
     /// Each variable's final value.
     pub(crate) final_values: Vec<f64>,
     /// How many iterations of Newton's method were required?
@@ -27,6 +29,11 @@ impl SolveOutcome {
     /// Which constraints couldn't be satisfied
     pub fn unsatisfied(&self) -> &[usize] {
         &self.unsatisfied
+    }
+
+    /// Did the solver converge on a solution?
+    pub fn converged(&self) -> bool {
+        self.converged
     }
 
     /// Each variable's final value.
@@ -165,6 +172,7 @@ mod tests {
             iterations: 1,
             warnings: Vec::new(),
             priority_solved: 0,
+            converged: Default::default(),
         };
 
         assert!(so.is_unsatisfied());

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -10,7 +10,10 @@ use super::Model;
 
 #[derive(Debug)]
 pub struct SuccessfulSolve {
+    /// How many iterations did the solver run for?
     pub iterations: usize,
+    /// Did it ultimately converge, or not?
+    pub converged: bool,
 }
 
 impl Model<'_> {
@@ -41,6 +44,7 @@ impl Model<'_> {
             if largest_absolute_elem <= config.convergence_tolerance {
                 return Ok(SuccessfulSolve {
                     iterations: this_iteration,
+                    converged: true,
                 });
             }
 
@@ -84,9 +88,13 @@ impl Model<'_> {
             if step_inf_norm <= step_threshold {
                 return Ok(SuccessfulSolve {
                     iterations: this_iteration,
+                    converged: true,
                 });
             }
         }
-        Err(NonLinearSystemError::DidNotConverge)
+        Ok(SuccessfulSolve {
+            iterations: config.max_iterations,
+            converged: false,
+        })
     }
 }

--- a/ezpz/src/textual/executor.rs
+++ b/ezpz/src/textual/executor.rs
@@ -515,6 +515,7 @@ impl ConstraintSystem<'_> {
                     final_values,
                     unsatisfied,
                     priority_solved,
+                    converged,
                 },
         } = self.solve_no_metadata_inner::<A>(config)?;
         let num_points = self.inner_points.len();
@@ -566,6 +567,7 @@ impl ConstraintSystem<'_> {
         Ok((
             analysis,
             Outcome {
+                converged,
                 priority_solved,
                 unsatisfied,
                 iterations,
@@ -606,6 +608,8 @@ pub struct Outcome {
     /// The constraint solver stops when it cannot solve any more constraints, i.e.
     /// got an error.
     pub priority_solved: u32,
+    /// Did the solver converge on a solution?
+    pub converged: bool,
 }
 
 /// Outcome of solving an ezpz system, and degrees-of-freedom analysis.


### PR DESCRIPTION
If the solver didn't converge, return the last solution, but add a bool to indicate that the system did not converge.

This way, consumers can use the last solution as a best-effort solve, just like if the system was
inconsistent.

Alternative to https://github.com/KittyCAD/ezpz/pull/264