### PR TITLE
Release 0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.2.26
+
+## Added
+
+ - Per-constraint weights (#260)
+
+## Changed
+
+ - DidNotConverge is no longer an error, instead, check the `.converged` property (#266)
+ - Faster freedom analysis (#263)
+
+# 0.2.25
+
+## Changed
+
+ - Bump faer
+ - Do floating-point math in libm rather than std::f64
+
 # 0.2.24
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "ezpz"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/ezpz/Cargo.toml
+++ b/ezpz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezpz"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2024"
 description = "A constraint solver for KCL and Zoo Design Studio"
 repository = "https://github.com/KittyCAD/ezpz"


### PR DESCRIPTION
## Added

 - Per-constraint weights (#260)

## Changed

 - DidNotConverge is no longer an error, instead, check the `.converged` property (#266)
 - Faster freedom analysis (#263)
