### PR TITLE
Add opt-in per-iteration condition-number diagnostic (#89)

### DIFF
--- a/ezpz/src/lib.rs
+++ b/ezpz/src/lib.rs
@@ -165,6 +165,7 @@ pub(crate) fn solve_with_priority_inner<A: Analysis>(
                 warnings: Vec::new(),
                 priority_solved: 0,
                 converged: true,
+                condition_numbers: Vec::new(),
             },
         });
     }
@@ -258,6 +259,7 @@ pub(crate) fn solve_with_priority_inner<A: Analysis>(
             warnings: Vec::new(),
             priority_solved: lowest_priority,
             converged: true,
+            condition_numbers: Vec::new(),
         },
     }))
 }
@@ -350,6 +352,7 @@ fn solve_inner<A: Analysis>(
             iterations: success.iterations,
             warnings,
             converged: success.converged,
+            condition_numbers: success.condition_numbers,
         },
         analysis,
     })

--- a/ezpz/src/solve_outcome.rs
+++ b/ezpz/src/solve_outcome.rs
@@ -23,6 +23,10 @@ pub struct SolveOutcome {
     /// What is the lowest priority that got solved?
     /// 0 is the highest priority. Larger numbers are lower priority.
     pub(crate) priority_solved: u32,
+    /// Estimated 2-norm condition number of the linear system solved at each
+    /// Newton iteration, in iteration order. Empty unless
+    /// [`crate::Config::with_condition_number_estimates`] was enabled.
+    pub(crate) condition_numbers: Vec<f64>,
 }
 
 impl SolveOutcome {
@@ -55,6 +59,21 @@ impl SolveOutcome {
     /// 0 is the highest priority. Larger numbers are lower priority.
     pub fn priority_solved(&self) -> u32 {
         self.priority_solved
+    }
+
+    /// Estimated 2-norm condition number of the linear system solved at each
+    /// Newton iteration, in iteration order.
+    ///
+    /// Empty unless [`crate::Config::with_condition_number_estimates`] was
+    /// enabled. A large value (say, above `1e8`) signals an ill-conditioned
+    /// system, typically redundant or nearly-parallel constraints, whose
+    /// solution may be inaccurate even when the solver reports convergence.
+    ///
+    /// The estimate is for the normal-equations matrix `A = JᵀJ + λI`. Since
+    /// `A = JᵀJ`, the condition number of the Jacobian itself is roughly the
+    /// square root of these values.
+    pub fn condition_numbers(&self) -> &[f64] {
+        &self.condition_numbers
     }
 
     /// Look up the solved value for this distance.
@@ -173,6 +192,7 @@ mod tests {
             warnings: Vec::new(),
             priority_solved: 0,
             converged: Default::default(),
+            condition_numbers: Vec::new(),
         };
 
         assert!(so.is_unsatisfied());

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -35,6 +35,12 @@ pub struct Config {
     convergence_tolerance: f64,
     /// Stop iterating if the step size becomes negligible (relative infinity norm).
     step_tolerance: f64,
+    /// If true, estimate the 2-norm condition number of the linear system
+    /// solved at each Newton iteration and report it via
+    /// [`crate::SolveOutcome::condition_numbers`]. Off by default because it
+    /// adds a little work per iteration; opt in when diagnosing numerical
+    /// trouble (e.g. redundant or nearly-parallel constraints).
+    estimate_condition_number: bool,
 }
 
 impl Config {
@@ -56,6 +62,18 @@ impl Config {
         self.step_tolerance = value;
         self
     }
+
+    /// Estimate the 2-norm condition number of the linear system solved at each
+    /// Newton iteration, reported via [`crate::SolveOutcome::condition_numbers`].
+    ///
+    /// Off by default, since it does extra work per iteration. A large condition
+    /// number means the system is close to singular (e.g. redundant or
+    /// nearly-parallel constraints), so the solve may be inaccurate even when it
+    /// converges.
+    pub fn with_condition_number_estimates(mut self, value: bool) -> Self {
+        self.estimate_condition_number = value;
+        self
+    }
 }
 
 impl Default for Config {
@@ -64,6 +82,7 @@ impl Default for Config {
             max_iterations: 35,
             convergence_tolerance: 1e-8,
             step_tolerance: 1e-12,
+            estimate_condition_number: false,
         }
     }
 }

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -14,6 +14,10 @@ pub struct SuccessfulSolve {
     pub iterations: usize,
     /// Did it ultimately converge, or not?
     pub converged: bool,
+    /// Estimated 2-norm condition number of the linear system solved at each
+    /// iteration, in iteration order. Empty unless
+    /// [`crate::Config::with_condition_number_estimates`] was enabled.
+    pub condition_numbers: Vec<f64>,
 }
 
 impl Model<'_> {
@@ -26,6 +30,13 @@ impl Model<'_> {
         let m = self.layout.total_num_residuals;
 
         let mut global_residual = vec![0.0; m];
+
+        // Per-iteration condition-number diagnostics (opt-in via Config).
+        let mut condition_numbers = if config.estimate_condition_number {
+            Vec::with_capacity(config.max_iterations)
+        } else {
+            Vec::new()
+        };
 
         for this_iteration in 0..config.max_iterations {
             // Assemble global residual and Jacobian
@@ -45,6 +56,7 @@ impl Model<'_> {
                 return Ok(SuccessfulSolve {
                     iterations: this_iteration,
                     converged: true,
+                    condition_numbers,
                 });
             }
 
@@ -65,6 +77,13 @@ impl Model<'_> {
 
             // Solve linear system
             let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
+            if config.estimate_condition_number {
+                condition_numbers.push(estimate_spd_condition_number(
+                    a.as_ref(),
+                    &factored,
+                    current_values.len(),
+                ));
+            }
             let d = factored.solve(&b);
             assert_eq!(
                 d.nrows(),
@@ -89,12 +108,172 @@ impl Model<'_> {
                 return Ok(SuccessfulSolve {
                     iterations: this_iteration,
                     converged: true,
+                    condition_numbers,
                 });
             }
         }
         Ok(SuccessfulSolve {
             iterations: config.max_iterations,
             converged: false,
+            condition_numbers,
         })
+    }
+}
+
+/// Estimate the 2-norm condition number of the SPD normal-equations matrix
+/// `A = JᵀJ + λI`, reusing the LU factorization computed for the Newton step.
+///
+/// For an SPD matrix the condition number is `λ_max / λ_min`. We get the two
+/// extreme eigenvalues with a few rounds of power iteration: directly on `A`
+/// for `λ_max`, and on `A⁻¹` for `λ_min` (`λ_min = 1 / λ_max(A⁻¹)`). The
+/// inverse step just applies the existing LU factorization, so it costs a
+/// couple of triangular solves rather than a fresh factorization.
+///
+/// `A = JᵀJ`, so this is the square of the Jacobian's condition number; take
+/// the square root if you want `cond(J)`.
+///
+/// Returns infinity if `A` is numerically singular, and `1.0` for an empty
+/// system.
+fn estimate_spd_condition_number(
+    a: SparseColMatRef<'_, usize, f64>,
+    factored: &Lu<usize, f64>,
+    n: usize,
+) -> f64 {
+    // Number of power-iteration rounds. A dozen is plenty for an order-of-
+    // magnitude diagnostic; this is not a high-precision eigensolve.
+    const POWER_ITERS: usize = 12;
+    if n == 0 {
+        return 1.0;
+    }
+
+    // Reusable buffers so the per-round work allocates nothing.
+    let mut v = vec![0.0; n];
+    let mut work = vec![0.0; n];
+
+    // λ_max(A): apply A directly.
+    let lambda_max = power_iteration(POWER_ITERS, &mut v, &mut work, |x, out| {
+        let prod = a * ColRef::from_slice(x);
+        out.iter_mut().zip(prod.iter()).for_each(|(o, p)| *o = *p);
+    });
+
+    // λ_max(A⁻¹) = 1 / λ_min(A): apply A⁻¹ via the existing factorization.
+    let lambda_max_inv = power_iteration(POWER_ITERS, &mut v, &mut work, |x, out| {
+        let prod = factored.solve(ColRef::from_slice(x));
+        out.iter_mut().zip(prod.iter()).for_each(|(o, p)| *o = *p);
+    });
+
+    if lambda_max_inv <= f64::EPSILON || !lambda_max_inv.is_finite() {
+        return f64::INFINITY;
+    }
+    let lambda_min = 1.0 / lambda_max_inv;
+    if lambda_min <= f64::EPSILON {
+        return f64::INFINITY;
+    }
+    lambda_max / lambda_min
+}
+
+/// Power iteration for the dominant eigenvalue magnitude of an SPD operator,
+/// where `apply` computes `out = M x` for the operator `M`.
+///
+/// `v` and `work` are caller-owned scratch buffers (length = operator
+/// dimension) and are both overwritten. The start vector is uniform so the
+/// result is deterministic. Returns the dominant eigenvalue magnitude, or `0.0`
+/// if the operator sends the iterate to (numerically) zero.
+fn power_iteration(
+    iters: usize,
+    v: &mut [f64],
+    work: &mut [f64],
+    mut apply: impl FnMut(&[f64], &mut [f64]),
+) -> f64 {
+    let n = v.len();
+    // Deterministic, non-degenerate start: the uniform unit vector.
+    let start = 1.0 / (n as f64).sqrt();
+    v.iter_mut().for_each(|x| *x = start);
+
+    let mut lambda = 0.0;
+    for _ in 0..iters {
+        apply(v, work);
+        let norm = work.iter().map(|x| x * x).sum::<f64>().sqrt();
+        if norm <= f64::EPSILON {
+            return 0.0;
+        }
+        lambda = norm;
+        let inv_norm = 1.0 / norm;
+        v.iter_mut()
+            .zip(work.iter())
+            .for_each(|(vi, &wi)| *vi = wi * inv_norm);
+    }
+    lambda
+}
+
+#[cfg(test)]
+mod cond_number_tests {
+    use super::{estimate_spd_condition_number, power_iteration};
+    use faer::sparse::{
+        SparseColMat, Triplet,
+        linalg::solvers::{Lu, SymbolicLu},
+    };
+
+    /// Build an SPD matrix from explicit entries and run the estimator on it,
+    /// going through the same LU path the solver uses.
+    fn estimate(entries: &[(usize, usize, f64)], n: usize) -> f64 {
+        let triplets: Vec<_> = entries
+            .iter()
+            .map(|&(i, j, v)| Triplet::new(i, j, v))
+            .collect();
+        let a = SparseColMat::<usize, f64>::try_new_from_triplets(n, n, &triplets).unwrap();
+        let symbolic = SymbolicLu::try_new(a.symbolic()).unwrap();
+        let factored = Lu::try_new_with_symbolic(symbolic, a.as_ref()).unwrap();
+        estimate_spd_condition_number(a.as_ref(), &factored, n)
+    }
+
+    #[test]
+    fn recovers_known_condition_numbers() {
+        // Identity: every singular value is 1, so the condition number is 1.
+        let id = estimate(&[(0, 0, 1.0), (1, 1, 1.0), (2, 2, 1.0)], 3);
+        assert!((id - 1.0).abs() < 1e-6, "identity κ should be 1, got {id}");
+
+        // Diagonal diag(1, 8, 64, 512): the eigenvalues are the diagonal, so the
+        // condition number is 512 / 1 = 512.
+        let diag = estimate(&[(0, 0, 1.0), (1, 1, 8.0), (2, 2, 64.0), (3, 3, 512.0)], 4);
+        assert!(
+            (diag - 512.0).abs() / 512.0 < 1e-3,
+            "diagonal κ should be 512, got {diag}"
+        );
+
+        // A dense (non-diagonal) SPD matrix with a known condition number:
+        // rotate diag(1, 1000) by θ = 0.4 rad. Orthogonal similarity leaves the
+        // eigenvalues at 1 and 1000 (κ = 1000) but fills in every entry.
+        //   A = Rᵀ diag(1, 1000) R,  R = [[c, -s], [s, c]]
+        let c = 0.921_060_994_002_885_1_f64; // cos(0.4)
+        let s = 0.389_418_342_308_650_5_f64; // sin(0.4)
+        let (d0, d1) = (1.0_f64, 1000.0_f64);
+        let a00 = c * c * d0 + s * s * d1;
+        let a11 = s * s * d0 + c * c * d1;
+        let a01 = c * s * (d1 - d0);
+        let rotated = estimate(&[(0, 0, a00), (0, 1, a01), (1, 0, a01), (1, 1, a11)], 2);
+        assert!(
+            (rotated - 1000.0).abs() / 1000.0 < 1e-2,
+            "rotated κ should be 1000, got {rotated}"
+        );
+    }
+
+    #[test]
+    fn power_iteration_recovers_dominant_eigenvalue() {
+        // Applying diag(2, 5, 9) is per-component scaling; the dominant
+        // eigenvalue is 9.
+        let diag = [2.0_f64, 5.0, 9.0];
+        let mut v = vec![0.0; 3];
+        let mut work = vec![0.0; 3];
+        let lambda = power_iteration(50, &mut v, &mut work, |x, out| {
+            out.iter_mut()
+                .zip(diag.iter())
+                .zip(x.iter())
+                .for_each(|((o, &d), &xi)| *o = d * xi);
+        });
+        assert!(
+            (lambda - 9.0).abs() < 1e-9,
+            "dominant eigenvalue should be 9, got {lambda}"
+        );
     }
 }

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -1915,3 +1915,85 @@ fn points_at_angle_sign_distinguishable() {
         );
     }
 }
+
+/// The condition-number diagnostic (issue #89) is opt-in, and reports one
+/// estimate per linear solve when enabled.
+///
+/// `A = JᵀJ + λI` is SPD, so its 2-norm condition number `λ_max / λ_min` is
+/// always `≥ 1`. This checks the plumbing and a few invariants: off (the
+/// default) nothing is collected; on, the series is non-empty, has at most one
+/// estimate per iteration (plus the solve that triggers the step-size return),
+/// and every estimate is finite and `≥ 1`.
+///
+/// No upper bound is asserted on purpose: this system is under-determined (one
+/// angle residual, eight coordinates), so `J` is rank-deficient and the
+/// regularized condition number is genuinely large, which is exactly the
+/// diagnostic flagging an under-constrained system.
+#[test]
+fn condition_number_estimate_is_opt_in_and_well_defined() {
+    let p0 = DatumPoint { x_id: 0, y_id: 1 };
+    let p1 = DatumPoint { x_id: 2, y_id: 3 };
+    let p2 = DatumPoint { x_id: 4, y_id: 5 };
+    let p3 = DatumPoint { x_id: 6, y_id: 7 };
+    let line0 = DatumLineSegment { p0, p1 };
+    let line1 = DatumLineSegment { p0: p2, p1: p3 };
+
+    let constraints = [ConstraintRequest::highest_priority(
+        Constraint::LinesAtAngle(
+            line0,
+            line1,
+            AngleKind::Other(Angle::from_radians(-0.5 * PI)),
+        ),
+    )];
+    let initial_guesses: Vec<(Id, f64)> = vec![
+        (0, 0.0),
+        (1, 0.0),
+        (2, 1.0),
+        (3, 0.0),
+        (4, 0.0),
+        (5, 0.0),
+        (6, 1.0),
+        (7, 1.0),
+    ];
+
+    // Default: diagnostic off, so nothing is collected.
+    let off = solve(
+        &constraints,
+        initial_guesses.clone(),
+        Config::default().with_max_iterations(100),
+    )
+    .expect("solve (diagnostic off)");
+    assert!(off.is_satisfied());
+    assert!(
+        off.condition_numbers().is_empty(),
+        "condition numbers must not be collected unless opted in"
+    );
+
+    // Opt in: one condition-number estimate per linear solve.
+    let on = solve(
+        &constraints,
+        initial_guesses,
+        Config::default()
+            .with_max_iterations(100)
+            .with_condition_number_estimates(true),
+    )
+    .expect("solve (diagnostic on)");
+    assert!(on.is_satisfied());
+
+    let kappas = on.condition_numbers();
+    assert!(
+        !kappas.is_empty(),
+        "expected at least one condition-number estimate when opted in"
+    );
+    assert!(
+        kappas.len() <= on.iterations() + 1,
+        "got {} estimates for {} iterations",
+        kappas.len(),
+        on.iterations()
+    );
+    for &k in kappas {
+        assert!(k.is_finite(), "condition number must be finite, got {k}");
+        // κ₂ = σ_max / σ_min ≥ 1 for any matrix; allow a hair of estimator slack.
+        assert!(k >= 1.0 - 1e-6, "condition number must be ≥ 1, got {k}");
+    }
+}

--- a/ezpz/src/textual/executor.rs
+++ b/ezpz/src/textual/executor.rs
@@ -516,6 +516,9 @@ impl ConstraintSystem<'_> {
                     unsatisfied,
                     priority_solved,
                     converged,
+                    // Surfacing condition-number diagnostics through the textual
+                    // CLI outcome is a separate follow-up; not needed here.
+                    condition_numbers: _,
                 },
         } = self.solve_no_metadata_inner::<A>(config)?;
         let num_points = self.inner_points.len();


### PR DESCRIPTION
Closes #89.

Heads-up: the issue mentions a QR solve, but the solver now LU-factors the normal equations `A = JᵀJ + λI` each iteration, so I report the condition number of `A`. Since `A = JᵀJ`, that's about `cond(J)²`. If you'd rather report `cond(J)` directly (a QR of J would avoid the squaring), I'm happy to switch — I went with `A` because it reuses the LU the solve already computes.

Opt-in, off by default:

```rust
Config::default().with_condition_number_estimates(true)
// outcome.condition_numbers(): one estimate per iteration
```

`A` is SPD, so cond = λmax/λmin. I use power iteration for λmax and inverse power iteration for λmin, reusing the LU factorization the Newton step already computed (just a couple of triangular solves). Deterministic start vector, reused buffers, singular `A` returns infinity.

Has unit tests: the opt-in/invariant behaviour through the solver, plus a correctness test of the estimator against matrices with known condition numbers (identity, a diagonal, and a rotated dense SPD matrix). clippy and fmt are clean.

Note: some `test_cases/*` tests fail locally, but they also fail on a clean main here, because the `problem.md` fixtures check out as CRLF on Windows and the parser trips on the `\r`. Unrelated to this change.
