### PR TITLE
Adaptive damping and scale-covariance

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,3 @@
 [default.extend-words]
 nd = "nd" # Name of variables used throughout newton-faer crate
+ue = "ue" # Math variable name (end - center) in Arc residual derivation

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,5 @@
 disallowed-methods = [
   { path = "f64::hypot",   reason = "Use trig functions from libm crate instead, to ensure FP math works the same across OSs and platforms."},
-  { path = "f64::min",   reason = "Use trig functions from libm crate instead, to ensure FP math works the same across OSs and platforms."},
-  { path = "f64::max",   reason = "Use trig functions from libm crate instead, to ensure FP math works the same across OSs and platforms."},
   { path = "f64::sin",   reason = "Use trig functions from libm crate instead, to ensure FP math works the same across OSs and platforms."},
   { path = "f64::sin_cos", reason = "Use trig functions from libm crate instead, to ensure FP math works the same across OSs and platforms."},
   { path = "f64::cos",   reason = "Use trig functions from libm crate instead, to ensure FP math works the same across OSs and platforms."},

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -627,17 +627,19 @@ impl Constraint {
                 let u = V::new(x1 - x0, y1 - y0);
                 let v = V::new(x3 - x2, y3 - y2);
 
-                let sqr_tol = EPSILON * EPSILON;
-                if (u.magnitude_squared() <= sqr_tol) || (v.magnitude_squared() <= sqr_tol) {
+                let len_u = u.magnitude();
+                let len_v = v.magnitude();
+                if len_u <= EPSILON || len_v <= EPSILON {
                     *degenerate = true;
                     return;
                 }
 
-                // We divide by the average arm length to make the residual length-covariant.
-                // Its Jacobian is then O(1) regardless of model scale.
+                // Residual: r = ((|u| + |v|)/2) (û × R⁻¹v̂)
                 let rot = rotation_for_angle_kind(*expected_angle);
-                let scale = (u.magnitude() + v.magnitude()) * 0.5;
-                *residual0 = u.cross_2d(rot.inverse().apply(v)) / scale;
+                let u_hat = u * (1.0 / len_u);
+                let v_hat = v * (1.0 / len_v);
+                let scale = (len_u + len_v) * 0.5;
+                *residual0 = scale * u_hat.cross_2d(rot.inverse().apply(v_hat));
             }
             Constraint::PointsCoincident(p0, p1) => {
                 let p0_x = current_assignments[layout.index_of(p0.id_x())];
@@ -938,10 +940,12 @@ impl Constraint {
                     return;
                 }
 
-                let rot = rotation_for_angle_kind(*expected_angle);
                 let u_hat = u * (1.0 / len_u);
                 let v_hat = v * (1.0 / len_v);
+
+                let rot = rotation_for_angle_kind(*expected_angle);
                 let rot_u_hat = rot.apply(u_hat);
+
                 let scale = (len_u + len_v) * 0.5;
                 let res = v_hat - rot_u_hat;
 
@@ -1378,22 +1382,39 @@ impl Constraint {
                     return;
                 }
 
-                let rot = rotation_for_angle_kind(*expected_angle);
-
-                let area = u.cross_2d(rot.inverse().apply(v));
-                let scale = (len_u + len_v) * 0.5;
-
                 let u_hat = u * (1.0 / len_u);
                 let v_hat = v * (1.0 / len_v);
 
-                let da_du = rot.inverse().apply(v).perp_cw();
-                let da_dv = rot.apply(u).perp_ccw();
+                let rot = rotation_for_angle_kind(*expected_angle);
+                let r_v = rot.inverse().apply(v_hat); // R⁻¹ v̂
+                let r_u = rot.apply(u_hat); // R û
+                let sin_diff = u_hat.cross_2d(r_v);
 
-                let inv_s = 1.0 / scale;
-                let t = area * inv_s * 0.5;
+                /*
+                    Residual
 
-                let df_du = (da_du - u_hat * t) * inv_s;
-                let df_dv = (da_dv - v_hat * t) * inv_s;
+                        r = s (û × R⁻¹v̂)
+
+                    Where
+
+                        s := (|u| + |v|) / 2
+
+                    Differentiate in u (via product rule)
+
+                        ∂r/∂u = (s/|u|)·w + û·(û × R⁻¹v̂)·(1/2 - s/|u|)
+
+                    Where
+
+                        w := perp_cw(R⁻¹v̂)
+
+                    Symmetric for v with w := perp_ccw(R û)
+                */
+
+                let s = (len_u + len_v) * 0.5;
+                let s_u = s / len_u;
+                let s_v = s / len_v;
+                let df_du = r_v.perp_cw() * s_u + u_hat * (sin_diff * (0.5 - s_u));
+                let df_dv = r_u.perp_ccw() * s_v + v_hat * (sin_diff * (0.5 - s_v));
 
                 let pds = PartialDerivatives4Points {
                     x0: -df_du.x,
@@ -2192,28 +2213,43 @@ impl Constraint {
 
                 let inv_len_u = 1.0 / len_u;
                 let inv_len_v = 1.0 / len_v;
-                let rot = rotation_for_angle_kind(*expected_angle);
                 let u_hat = u * inv_len_u;
                 let v_hat = v * inv_len_v;
+
+                let rot = rotation_for_angle_kind(*expected_angle);
                 let rot_u_hat = rot.apply(u_hat);
+
                 let scale = (len_u + len_v) * 0.5;
-                let res = v_hat - rot_u_hat;
+                let diff = v_hat - rot_u_hat;
+
+                /*
+                    Residual
+
+                        r = s (v̂ - R û)
+
+                    Where
+
+                        s := (|u| + |v|) / 2
+
+                    Differentiate in u and v (via product rule)
+
+                        ∂r/∂u = (û / 2) rᵀ + s |u|⁻¹ (R û ûᵀ - R)
+                        ∂r/∂v = (v̂ / 2) rᵀ + s |v|⁻¹ (I - v̂ v̂ᵀ)
+                */
 
                 // Columns of R: R*e1 = (ca, sa), R*e2 = (-sa, ca)
                 let rot_e1 = rot.apply(V::new(1.0, 0.0));
                 let rot_e2 = rot.apply(V::new(0.0, 1.0));
 
                 // ∂r/∂u
-                let dr_du0 =
-                    res * (u_hat.x * 0.5) + (rot_u_hat * u_hat.x - rot_e1) * (scale * inv_len_u);
-                let dr_du1 =
-                    res * (u_hat.y * 0.5) + (rot_u_hat * u_hat.y - rot_e2) * (scale * inv_len_u);
+                let s_u = scale * inv_len_u;
+                let dr_du0 = diff * (u_hat.x * 0.5) + (rot_u_hat * u_hat.x - rot_e1) * s_u;
+                let dr_du1 = diff * (u_hat.y * 0.5) + (rot_u_hat * u_hat.y - rot_e2) * s_u;
 
                 // ∂r/∂v
-                let dr_dv0 = res * (v_hat.x * 0.5)
-                    + (V::new(1.0, 0.0) - v_hat * v_hat.x) * (scale * inv_len_v);
-                let dr_dv1 = res * (v_hat.y * 0.5)
-                    + (V::new(0.0, 1.0) - v_hat * v_hat.y) * (scale * inv_len_v);
+                let s_v = scale * inv_len_v;
+                let dr_dv0 = diff * (v_hat.x * 0.5) + (V::new(1.0, 0.0) - v_hat * v_hat.x) * s_v;
+                let dr_dv1 = diff * (v_hat.y * 0.5) + (V::new(0.0, 1.0) - v_hat * v_hat.y) * s_v;
 
                 // ∂r/∂p0 = -(∂r/∂u + ∂r/∂v)
                 // ∂r/∂p1 = ∂r/∂u

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -11,6 +11,10 @@ use std::f64::consts::PI;
 /// existing constraints.
 mod composite;
 
+// DEBUG(dr): For testing purposes
+const LINES_AT_ANGLE_HARMONIC: bool = true;
+const POINTS_AT_ANGLE_HARMONIC: bool = true;
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ConstraintEntry<'c> {
     /// The constraint itself.
@@ -634,12 +638,17 @@ impl Constraint {
                     return;
                 }
 
-                // Residual: r = ((|u| + |v|)/2) (û × R⁻¹v̂)
                 let rot = rotation_for_angle_kind(*expected_angle);
-                let u_hat = u * (1.0 / len_u);
-                let v_hat = v * (1.0 / len_v);
-                let scale = (len_u + len_v) * 0.5;
-                *residual0 = scale * u_hat.cross_2d(rot.inverse().apply(v_hat));
+                let s = (len_u + len_v) * 0.5;
+                *residual0 = if LINES_AT_ANGLE_HARMONIC {
+                    // Residual (harmonic mean form): r = (u × R⁻¹v) / s
+                    u.cross_2d(rot.inverse().apply(v)) / s
+                } else {
+                    // Residual (arithmetic mean form): r = s (û × R⁻¹v̂)
+                    let u_hat = u * (1.0 / len_u);
+                    let v_hat = v * (1.0 / len_v);
+                    s * u_hat.cross_2d(rot.inverse().apply(v_hat))
+                };
             }
             Constraint::PointsCoincident(p0, p1) => {
                 let p0_x = current_assignments[layout.index_of(p0.id_x())];
@@ -940,18 +949,21 @@ impl Constraint {
                     return;
                 }
 
-                let u_hat = u * (1.0 / len_u);
-                let v_hat = v * (1.0 / len_v);
-
                 let rot = rotation_for_angle_kind(*expected_angle);
-                let rot_u_hat = rot.apply(u_hat);
+                let s = (len_u + len_v) * 0.5;
 
-                let scale = (len_u + len_v) * 0.5;
-                let res = v_hat - rot_u_hat;
+                let res = if POINTS_AT_ANGLE_HARMONIC {
+                    // Residual (harmonic mean form): r = (|u| v - |v| R u) / s
+                    (v * len_u - rot.apply(u) * len_v) * (1.0 / s)
+                } else {
+                    // Residual (arithmetic mean form): r = s (v̂ - R û)
+                    let u_hat = u * (1.0 / len_u);
+                    let v_hat = v * (1.0 / len_v);
+                    (v_hat - rot.apply(u_hat)) * s
+                };
 
-                // Residual: r = (|u| + |v|) / 2 * (v_hat - R * u_hat)
-                *residual0 = scale * res.x;
-                *residual1 = scale * res.y;
+                *residual0 = res.x;
+                *residual1 = res.y;
             }
         }
     }
@@ -1386,35 +1398,60 @@ impl Constraint {
                 let v_hat = v * (1.0 / len_v);
 
                 let rot = rotation_for_angle_kind(*expected_angle);
-                let r_v = rot.inverse().apply(v_hat); // R⁻¹ v̂
-                let r_u = rot.apply(u_hat); // R û
-                let sin_diff = u_hat.cross_2d(r_v);
-
-                /*
-                    Residual
-
-                        r = s (û × R⁻¹v̂)
-
-                    Where
-
-                        s := (|u| + |v|) / 2
-
-                    Differentiate in u (via product rule)
-
-                        ∂r/∂u = (s/|u|)·w + û·(û × R⁻¹v̂)·(1/2 - s/|u|)
-
-                    Where
-
-                        w := perp_cw(R⁻¹v̂)
-
-                    Symmetric for v with w := perp_ccw(R û)
-                */
-
                 let s = (len_u + len_v) * 0.5;
-                let s_u = s / len_u;
-                let s_v = s / len_v;
-                let df_du = r_v.perp_cw() * s_u + u_hat * (sin_diff * (0.5 - s_u));
-                let df_dv = r_u.perp_ccw() * s_v + v_hat * (sin_diff * (0.5 - s_v));
+
+                let (df_du, df_dv) = if LINES_AT_ANGLE_HARMONIC {
+                    /*
+                        Residual (harmonic mean form)
+
+                            r = a / s
+                            a := u × R⁻¹v
+                            s := (|u| + |v|) / 2
+
+                        Differentiate in u (via quotient rule)
+
+                            ∂a/∂u = perp_cw(R⁻¹v)
+                            ∂s/∂u = û/2
+                            ∂r/∂u = ((∂a/∂u) - (a/s)·(∂s/∂u)) / s
+
+                        Symmetric for v with ∂a/∂v = perp_ccw(R u), ∂s/∂v = v̂/2
+                    */
+                    let a = u.cross_2d(rot.inverse().apply(v));
+                    let inv_s = 1.0 / s;
+                    let t = a * inv_s * 0.5;
+                    (
+                        (rot.inverse().apply(v).perp_cw() - u_hat * t) * inv_s,
+                        (rot.apply(u).perp_ccw() - v_hat * t) * inv_s,
+                    )
+                } else {
+                    /*
+                        Residual (arithmetic mean form)
+
+                            r = s a
+                            a := û × R⁻¹v̂
+                            s := (|u| + |v|) / 2
+
+                        Differentiate in u (via product/chain rule)
+
+                            ∂s/∂u = û/2
+                            ∂a/∂u = (∂a/∂û) (∂û/∂u) = (perp_cw(R⁻¹v̂)) ((I − û ûᵀ)/|u|) = ((∂a/∂û) − a û)/|u|
+                            ∂r/∂u = (∂s/∂u) a + s (∂a/∂u) = (s/|u|) (∂a/∂û) + û a (1/2 − s/|u|)
+
+                        Symmetric in v with
+
+                            ∂s/∂v = v̂/2
+                            ∂a/∂v̂ = perp_ccw(R û)
+                    */
+                    let r_v = rot.inverse().apply(v_hat);
+                    let r_u = rot.apply(u_hat);
+                    let sin_diff = u_hat.cross_2d(r_v);
+                    let s_u = s / len_u;
+                    let s_v = s / len_v;
+                    (
+                        r_v.perp_cw() * s_u + u_hat * (sin_diff * (0.5 - s_u)),
+                        r_u.perp_ccw() * s_v + v_hat * (sin_diff * (0.5 - s_v)),
+                    )
+                };
 
                 let pds = PartialDerivatives4Points {
                     x0: -df_du.x,
@@ -2217,39 +2254,62 @@ impl Constraint {
                 let v_hat = v * inv_len_v;
 
                 let rot = rotation_for_angle_kind(*expected_angle);
-                let rot_u_hat = rot.apply(u_hat);
-
-                let scale = (len_u + len_v) * 0.5;
-                let diff = v_hat - rot_u_hat;
-
-                /*
-                    Residual
-
-                        r = s (v̂ - R û)
-
-                    Where
-
-                        s := (|u| + |v|) / 2
-
-                    Differentiate in u and v (via product rule)
-
-                        ∂r/∂u = (û / 2) rᵀ + s |u|⁻¹ (R û ûᵀ - R)
-                        ∂r/∂v = (v̂ / 2) rᵀ + s |v|⁻¹ (I - v̂ v̂ᵀ)
-                */
+                let s = (len_u + len_v) * 0.5;
 
                 // Columns of R: R*e1 = (ca, sa), R*e2 = (-sa, ca)
                 let rot_e1 = rot.apply(V::new(1.0, 0.0));
                 let rot_e2 = rot.apply(V::new(0.0, 1.0));
 
-                // ∂r/∂u
-                let s_u = scale * inv_len_u;
-                let dr_du0 = diff * (u_hat.x * 0.5) + (rot_u_hat * u_hat.x - rot_e1) * s_u;
-                let dr_du1 = diff * (u_hat.y * 0.5) + (rot_u_hat * u_hat.y - rot_e2) * s_u;
+                let (dr_du0, dr_du1, dr_dv0, dr_dv1) = if POINTS_AT_ANGLE_HARMONIC {
+                    /*
+                        Residual (harmonic mean form)
 
-                // ∂r/∂v
-                let s_v = scale * inv_len_v;
-                let dr_dv0 = diff * (v_hat.x * 0.5) + (V::new(1.0, 0.0) - v_hat * v_hat.x) * s_v;
-                let dr_dv1 = diff * (v_hat.y * 0.5) + (V::new(0.0, 1.0) - v_hat * v_hat.y) * s_v;
+                            r = a / s
+                            a := (|u| v - |v| R u)
+                            s := (|u| + |v|) / 2
+
+                        Differentiate in u and v (via quotient/chain rule)
+
+                            ∂a/∂u = v ûᵀ - |v| R
+                            ∂r/∂u = (∂a/∂u - r (∂s/∂u)ᵀ) / s = ((v - r/2) ûᵀ - |v| R) / s
+
+                            ∂a/∂v = |u| I - (R u) v̂ᵀ
+                            ∂r/∂v = (∂a/∂v - r (∂s/∂v)ᵀ) / s = (|u| I - (R u + r/2) v̂ᵀ) / s
+                    */
+                    let inv_s = 1.0 / s;
+                    let rot_u = rot.apply(u);
+                    let res = (v * len_u - rot_u * len_v) * inv_s;
+                    let half_res = res * 0.5;
+                    (
+                        ((v - half_res) * u_hat.x - rot_e1 * len_v) * inv_s,
+                        ((v - half_res) * u_hat.y - rot_e2 * len_v) * inv_s,
+                        (V::new(len_u, 0.0) - (rot_u + half_res) * v_hat.x) * inv_s,
+                        (V::new(0.0, len_u) - (rot_u + half_res) * v_hat.y) * inv_s,
+                    )
+                } else {
+                    /*
+                        Residual (arithmetic mean form)
+
+                            r = s a
+                            a := v̂ - R û
+                            s := (|u| + |v|) / 2
+
+                        Differentiate in u and v (via product/chain rule)
+
+                            ∂r/∂u = (û / 2) rᵀ + s |u|⁻¹ (R û ûᵀ - R)
+                            ∂r/∂v = (v̂ / 2) rᵀ + s |v|⁻¹ (I - v̂ v̂ᵀ)
+                    */
+                    let rot_u_hat = rot.apply(u_hat);
+                    let diff = v_hat - rot_u_hat;
+                    let s_u = s * inv_len_u;
+                    let s_v = s * inv_len_v;
+                    (
+                        diff * (u_hat.x * 0.5) + (rot_u_hat * u_hat.x - rot_e1) * s_u,
+                        diff * (u_hat.y * 0.5) + (rot_u_hat * u_hat.y - rot_e2) * s_u,
+                        diff * (v_hat.x * 0.5) + (V::new(1.0, 0.0) - v_hat * v_hat.x) * s_v,
+                        diff * (v_hat.y * 0.5) + (V::new(0.0, 1.0) - v_hat * v_hat.y) * s_v,
+                    )
+                };
 
                 // ∂r/∂p0 = -(∂r/∂u + ∂r/∂v)
                 // ∂r/∂p1 = ∂r/∂u

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -11,10 +11,6 @@ use std::f64::consts::PI;
 /// existing constraints.
 mod composite;
 
-// DEBUG(dr): For testing purposes
-const LINES_AT_ANGLE_HARMONIC: bool = true;
-const POINTS_AT_ANGLE_HARMONIC: bool = true;
-
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ConstraintEntry<'c> {
     /// The constraint itself.
@@ -639,16 +635,8 @@ impl Constraint {
                 }
 
                 let rot = rotation_for_angle_kind(*expected_angle);
-                let s = (len_u + len_v) * 0.5;
-                *residual0 = if LINES_AT_ANGLE_HARMONIC {
-                    // Residual (harmonic mean form): r = (u × R⁻¹v) / s
-                    u.cross_2d(rot.inverse().apply(v)) / s
-                } else {
-                    // Residual (arithmetic mean form): r = s (û × R⁻¹v̂)
-                    let u_hat = u * (1.0 / len_u);
-                    let v_hat = v * (1.0 / len_v);
-                    s * u_hat.cross_2d(rot.inverse().apply(v_hat))
-                };
+                // Residual: r = (u × R⁻¹v) / ((|u| + |v|)/2)
+                *residual0 = u.cross_2d(rot.inverse().apply(v)) / ((len_u + len_v) * 0.5);
             }
             Constraint::PointsCoincident(p0, p1) => {
                 let p0_x = current_assignments[layout.index_of(p0.id_x())];
@@ -952,15 +940,8 @@ impl Constraint {
                 let rot = rotation_for_angle_kind(*expected_angle);
                 let s = (len_u + len_v) * 0.5;
 
-                let res = if POINTS_AT_ANGLE_HARMONIC {
-                    // Residual (harmonic mean form): r = (|u| v - |v| R u) / s
-                    (v * len_u - rot.apply(u) * len_v) * (1.0 / s)
-                } else {
-                    // Residual (arithmetic mean form): r = s (v̂ - R û)
-                    let u_hat = u * (1.0 / len_u);
-                    let v_hat = v * (1.0 / len_v);
-                    (v_hat - rot.apply(u_hat)) * s
-                };
+                // Residual: r = (|u| v - |v| R u) / ((|u| + |v|)/2)
+                let res = (v * len_u - rot.apply(u) * len_v) * (1.0 / s);
 
                 *residual0 = res.x;
                 *residual1 = res.y;
@@ -1400,58 +1381,26 @@ impl Constraint {
                 let rot = rotation_for_angle_kind(*expected_angle);
                 let s = (len_u + len_v) * 0.5;
 
-                let (df_du, df_dv) = if LINES_AT_ANGLE_HARMONIC {
-                    /*
-                        Residual (harmonic mean form)
+                /*
+                    Residual
 
-                            r = a / s
-                            a := u × R⁻¹v
-                            s := (|u| + |v|) / 2
+                        r = a / s
+                        a := u × R⁻¹v
+                        s := (|u| + |v|) / 2
 
-                        Differentiate in u (via quotient rule)
+                    Differentiate in u (via quotient rule)
 
-                            ∂a/∂u = perp_cw(R⁻¹v)
-                            ∂s/∂u = û/2
-                            ∂r/∂u = ((∂a/∂u) - (a/s)·(∂s/∂u)) / s
+                        ∂a/∂u = perp_cw(R⁻¹v)
+                        ∂s/∂u = û/2
+                        ∂r/∂u = ((∂a/∂u) - (a/s)·(∂s/∂u)) / s
 
-                        Symmetric for v with ∂a/∂v = perp_ccw(R u), ∂s/∂v = v̂/2
-                    */
-                    let a = u.cross_2d(rot.inverse().apply(v));
-                    let inv_s = 1.0 / s;
-                    let t = a * inv_s * 0.5;
-                    (
-                        (rot.inverse().apply(v).perp_cw() - u_hat * t) * inv_s,
-                        (rot.apply(u).perp_ccw() - v_hat * t) * inv_s,
-                    )
-                } else {
-                    /*
-                        Residual (arithmetic mean form)
-
-                            r = s a
-                            a := û × R⁻¹v̂
-                            s := (|u| + |v|) / 2
-
-                        Differentiate in u (via product/chain rule)
-
-                            ∂s/∂u = û/2
-                            ∂a/∂u = (∂a/∂û) (∂û/∂u) = (perp_cw(R⁻¹v̂)) ((I − û ûᵀ)/|u|) = ((∂a/∂û) − a û)/|u|
-                            ∂r/∂u = (∂s/∂u) a + s (∂a/∂u) = (s/|u|) (∂a/∂û) + û a (1/2 − s/|u|)
-
-                        Symmetric in v with
-
-                            ∂s/∂v = v̂/2
-                            ∂a/∂v̂ = perp_ccw(R û)
-                    */
-                    let r_v = rot.inverse().apply(v_hat);
-                    let r_u = rot.apply(u_hat);
-                    let sin_diff = u_hat.cross_2d(r_v);
-                    let s_u = s / len_u;
-                    let s_v = s / len_v;
-                    (
-                        r_v.perp_cw() * s_u + u_hat * (sin_diff * (0.5 - s_u)),
-                        r_u.perp_ccw() * s_v + v_hat * (sin_diff * (0.5 - s_v)),
-                    )
-                };
+                    Symmetric for v with ∂a/∂v = perp_ccw(R u), ∂s/∂v = v̂/2
+                */
+                let a = u.cross_2d(rot.inverse().apply(v));
+                let inv_s = 1.0 / s;
+                let t = a * inv_s * 0.5;
+                let df_du = (rot.inverse().apply(v).perp_cw() - u_hat * t) * inv_s;
+                let df_dv = (rot.apply(u).perp_ccw() - v_hat * t) * inv_s;
 
                 let pds = PartialDerivatives4Points {
                     x0: -df_du.x,
@@ -2260,56 +2209,29 @@ impl Constraint {
                 let rot_e1 = rot.apply(V::new(1.0, 0.0));
                 let rot_e2 = rot.apply(V::new(0.0, 1.0));
 
-                let (dr_du0, dr_du1, dr_dv0, dr_dv1) = if POINTS_AT_ANGLE_HARMONIC {
-                    /*
-                        Residual (harmonic mean form)
+                /*
+                    Residual
 
-                            r = a / s
-                            a := (|u| v - |v| R u)
-                            s := (|u| + |v|) / 2
+                        r = a / s
+                        a := (|u| v - |v| R u)
+                        s := (|u| + |v|) / 2
 
-                        Differentiate in u and v (via quotient/chain rule)
+                    Differentiate in u and v (via quotient/chain rule)
 
-                            ∂a/∂u = v ûᵀ - |v| R
-                            ∂r/∂u = (∂a/∂u - r (∂s/∂u)ᵀ) / s = ((v - r/2) ûᵀ - |v| R) / s
+                        ∂a/∂u = v ûᵀ - |v| R
+                        ∂r/∂u = (∂a/∂u - r (∂s/∂u)ᵀ) / s = ((v - r/2) ûᵀ - |v| R) / s
 
-                            ∂a/∂v = |u| I - (R u) v̂ᵀ
-                            ∂r/∂v = (∂a/∂v - r (∂s/∂v)ᵀ) / s = (|u| I - (R u + r/2) v̂ᵀ) / s
-                    */
-                    let inv_s = 1.0 / s;
-                    let rot_u = rot.apply(u);
-                    let res = (v * len_u - rot_u * len_v) * inv_s;
-                    let half_res = res * 0.5;
-                    (
-                        ((v - half_res) * u_hat.x - rot_e1 * len_v) * inv_s,
-                        ((v - half_res) * u_hat.y - rot_e2 * len_v) * inv_s,
-                        (V::new(len_u, 0.0) - (rot_u + half_res) * v_hat.x) * inv_s,
-                        (V::new(0.0, len_u) - (rot_u + half_res) * v_hat.y) * inv_s,
-                    )
-                } else {
-                    /*
-                        Residual (arithmetic mean form)
-
-                            r = s a
-                            a := v̂ - R û
-                            s := (|u| + |v|) / 2
-
-                        Differentiate in u and v (via product/chain rule)
-
-                            ∂r/∂u = (û / 2) rᵀ + s |u|⁻¹ (R û ûᵀ - R)
-                            ∂r/∂v = (v̂ / 2) rᵀ + s |v|⁻¹ (I - v̂ v̂ᵀ)
-                    */
-                    let rot_u_hat = rot.apply(u_hat);
-                    let diff = v_hat - rot_u_hat;
-                    let s_u = s * inv_len_u;
-                    let s_v = s * inv_len_v;
-                    (
-                        diff * (u_hat.x * 0.5) + (rot_u_hat * u_hat.x - rot_e1) * s_u,
-                        diff * (u_hat.y * 0.5) + (rot_u_hat * u_hat.y - rot_e2) * s_u,
-                        diff * (v_hat.x * 0.5) + (V::new(1.0, 0.0) - v_hat * v_hat.x) * s_v,
-                        diff * (v_hat.y * 0.5) + (V::new(0.0, 1.0) - v_hat * v_hat.y) * s_v,
-                    )
-                };
+                        ∂a/∂v = |u| I - (R u) v̂ᵀ
+                        ∂r/∂v = (∂a/∂v - r (∂s/∂v)ᵀ) / s = (|u| I - (R u + r/2) v̂ᵀ) / s
+                */
+                let inv_s = 1.0 / s;
+                let rot_u = rot.apply(u);
+                let res = (v * len_u - rot_u * len_v) * inv_s;
+                let half_res = res * 0.5;
+                let dr_du0 = ((v - half_res) * u_hat.x - rot_e1 * len_v) * inv_s;
+                let dr_du1 = ((v - half_res) * u_hat.y - rot_e2 * len_v) * inv_s;
+                let dr_dv0 = (V::new(len_u, 0.0) - (rot_u + half_res) * v_hat.x) * inv_s;
+                let dr_dv1 = (V::new(0.0, len_u) - (rot_u + half_res) * v_hat.y) * inv_s;
 
                 // ∂r/∂p0 = -(∂r/∂u + ∂r/∂v)
                 // ∂r/∂p1 = ∂r/∂u

--- a/ezpz/src/constraints.rs
+++ b/ezpz/src/constraints.rs
@@ -633,8 +633,11 @@ impl Constraint {
                     return;
                 }
 
+                // We divide by the average arm length to make the residual length-covariant.
+                // Its Jacobian is then O(1) regardless of model scale.
                 let rot = rotation_for_angle_kind(*expected_angle);
-                *residual0 = u.cross_2d(rot.inverse().apply(v));
+                let scale = (u.magnitude() + v.magnitude()) * 0.5;
+                *residual0 = u.cross_2d(rot.inverse().apply(v)) / scale;
             }
             Constraint::PointsCoincident(p0, p1) => {
                 let p0_x = current_assignments[layout.index_of(p0.id_x())];
@@ -685,13 +688,12 @@ impl Constraint {
                 let end_y = current_assignments[layout.index_of(arc.end.id_y())];
                 let cx = current_assignments[layout.index_of(arc.center.id_x())];
                 let cy = current_assignments[layout.index_of(arc.center.id_y())];
-                // For numerical stability and simpler derivatives, we compare the squared
-                // distances. The residual is zero if the distances are equal.
-                // R = distance(center, start)² - distance(center, end)²
-                let dist0_sq = libm::pow(start_x - cx, 2.0) + libm::pow(start_y - cy, 2.0);
-                let dist1_sq = libm::pow(end_x - cx, 2.0) + libm::pow(end_y - cy, 2.0);
 
-                *residual0 = dist0_sq - dist1_sq;
+                // R = distance(center, start) - distance(center, end)
+                let dist0 = libm::hypot(start_x - cx, start_y - cy);
+                let dist1 = libm::hypot(end_x - cx, end_y - cy);
+
+                *residual0 = dist0 - dist1;
             }
             Constraint::Midpoint(line, point) => {
                 let p = line.p0;
@@ -856,57 +858,42 @@ impl Constraint {
                 }
             }
             Constraint::ArcLength(circular_arc, d) => {
-                // Residual math, see ezpz-sympy for notebook.
-                // u = a - c
-                // v = b - c
-                // ux = u[0]
-                // uy = u[1]
-                // vx = v[0]
-                // vy = v[1]
+                // An arc of length d on a circle of radius r subtends an angle α = d / r. The end
+                // point must therefore equal the start point rotated about the center by α. Writing
+                // the residual as the *vector* difference
                 //
-                // r = u.norm()
+                //     res = (b - c) - R(α)·(a - c),   α = d / r,   r = |a - c|
                 //
-                // cos_theta = u.dot(v) / (r**2)
-                // sin_theta = ux * vy - uy * vx
-                // # Target angle
-                // alpha = d / r
-                //
-                // # Residuals
-                // res0 = cos_theta - sp.cos(alpha)
-                // res1 = sin_theta - sp.sin(alpha)
-
+                // gives it length units, so its Jacobian entries stay O(1) regardless of model
+                // scale.
                 let cx = current_assignments[layout.index_of(circular_arc.center.id_x())];
                 let cy = current_assignments[layout.index_of(circular_arc.center.id_y())];
                 let ax = current_assignments[layout.index_of(circular_arc.start.id_x())];
                 let ay = current_assignments[layout.index_of(circular_arc.start.id_y())];
                 let bx = current_assignments[layout.index_of(circular_arc.end.id_x())];
                 let by = current_assignments[layout.index_of(circular_arc.end.id_y())];
-                let dx = ax - cx;
-                let dy = ay - cy;
-                let r2 = dx * dx + dy * dy;
-                if r2 < EPSILON {
+
+                let ux = ax - cx;
+                let uy = ay - cy;
+                let r2 = ux * ux + uy * uy;
+
+                if r2 <= EPSILON * EPSILON {
                     *residual0 = 0.0;
                     *residual1 = 0.0;
                     *degenerate = true;
                     return;
                 }
-                let res0 = ((ax - cx) * (bx - cx) + (ay - cy) * (by - cy))
-                    * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0)).recip()
-                    - libm::cos(
-                        d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                            .sqrt()
-                            .recip(),
-                    );
-                let res1 = ((ax - cx) * (by - cy) - (ay - cy) * (bx - cx))
-                    * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0)).recip()
-                    - libm::sin(
-                        d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                            .sqrt()
-                            .recip(),
-                    );
 
-                *residual0 = res0;
-                *residual1 = res1;
+                let alpha = d / r2.sqrt();
+                let sa = libm::sin(alpha);
+                let ca = libm::cos(alpha);
+
+                // R(α)·u
+                let rux = ca * ux - sa * uy;
+                let ruy = sa * ux + ca * uy;
+
+                *residual0 = (bx - cx) - rux;
+                *residual1 = (by - cy) - ruy;
             }
             Constraint::ArcAngle(circular_arc, angle) => Constraint::LinesAtAngle(
                 DatumLineSegment {
@@ -1384,15 +1371,29 @@ impl Constraint {
                 let u = V::new(x1 - x0, y1 - y0);
                 let v = V::new(x3 - x2, y3 - y2);
 
-                let sqr_tol = EPSILON * EPSILON;
-                if (u.magnitude_squared() <= sqr_tol) || (v.magnitude_squared() <= sqr_tol) {
+                let len_u = u.magnitude();
+                let len_v = v.magnitude();
+                if (len_u <= EPSILON) || (len_v <= EPSILON) {
                     *degenerate = true;
                     return;
                 }
 
                 let rot = rotation_for_angle_kind(*expected_angle);
-                let df_du = rot.inverse().apply(v).perp_cw();
-                let df_dv = rot.apply(u).perp_ccw();
+
+                let area = u.cross_2d(rot.inverse().apply(v));
+                let scale = (len_u + len_v) * 0.5;
+
+                let u_hat = u * (1.0 / len_u);
+                let v_hat = v * (1.0 / len_v);
+
+                let da_du = rot.inverse().apply(v).perp_cw();
+                let da_dv = rot.apply(u).perp_ccw();
+
+                let inv_s = 1.0 / scale;
+                let t = area * inv_s * 0.5;
+
+                let df_du = (da_du - u_hat * t) * inv_s;
+                let df_dv = (da_dv - v_hat * t) * inv_s;
 
                 let pds = PartialDerivatives4Points {
                     x0: -df_du.x,
@@ -1527,15 +1528,11 @@ impl Constraint {
                 );
             }
             Constraint::Arc(arc) => {
-                // Residual: R = (x_start-xc)²+(y_start-yc)² - (x_end-xc)²-(y_end-yc)² + CCW_constraint
-                // The partial derivatives for distance part:
-                // ∂R/∂x_start = 2*(x_start-xc)
-                // ∂R/∂y_start = 2*(y_start-yc)
-                // ∂R/∂x_end = -2*(x_end-xc)
-                // ∂R/∂y_end = -2*(y_end-yc)
-                // ∂R/∂xc = 2*(x_end-x_start)
-                // ∂R/∂yc = 2*(y_end-y_start)
-                // Plus derivatives for CCW constraint when cross < 0
+                // Residual: R = |start - c| - |end - c|. With us = start - c and ue = end - c,
+                // the partials are unit-vector components (O(1), scale-invariant):
+                // ∂R/∂start = us / |us|
+                // ∂R/∂end   = -ue / |ue|
+                // ∂R/∂c     = -us / |us| + ue / |ue|
 
                 let start_x = current_assignments[layout.index_of(arc.start.id_x())];
                 let start_y = current_assignments[layout.index_of(arc.start.id_y())];
@@ -1544,15 +1541,26 @@ impl Constraint {
                 let cx = current_assignments[layout.index_of(arc.center.id_x())];
                 let cy = current_assignments[layout.index_of(arc.center.id_y())];
 
-                // TODO: Handle degenerate case here
+                let usx = start_x - cx;
+                let usy = start_y - cy;
+
+                let uex = end_x - cx;
+                let uey = end_y - cy;
+
+                let dist0 = libm::hypot(usx, usy);
+                let dist1 = libm::hypot(uex, uey);
+                if dist0 <= EPSILON || dist1 <= EPSILON {
+                    *degenerate = true;
+                    return;
+                }
 
                 // Calculate derivative values for distance constraint.
-                let dx_start = (start_x - cx) * 2.0;
-                let dy_start = (start_y - cy) * 2.0;
-                let dx_end = (end_x - cx) * -2.0;
-                let dy_end = (end_y - cy) * -2.0;
-                let dx_c = (end_x - start_x) * 2.0;
-                let dy_c = (end_y - start_y) * 2.0;
+                let dx_start = usx / dist0;
+                let dy_start = usy / dist0;
+                let dx_end = -uex / dist1;
+                let dy_end = -uey / dist1;
+                let dx_c = -usx / dist0 + uex / dist1;
+                let dy_c = -usy / dist0 + uey / dist1;
 
                 row0.extend([
                     JacobianVar {
@@ -2047,7 +2055,6 @@ impl Constraint {
                 ]);
             }
             Constraint::ArcLength(circular_arc, d) => {
-                // First, get all the variables.
                 let id_cx = circular_arc.center.id_x();
                 let id_cy = circular_arc.center.id_y();
                 let id_ax = circular_arc.start.id_x();
@@ -2058,110 +2065,42 @@ impl Constraint {
                 let cy = current_assignments[layout.index_of(id_cy)];
                 let ax = current_assignments[layout.index_of(id_ax)];
                 let ay = current_assignments[layout.index_of(id_ay)];
-                let bx = current_assignments[layout.index_of(id_bx)];
-                let by = current_assignments[layout.index_of(id_by)];
-                let dx = ax - cx;
-                let dy = ay - cy;
-                let r2 = dx * dx + dy * dy;
-                if r2 < EPSILON {
+
+                let ux = ax - cx;
+                let uy = ay - cy;
+                let r2 = ux * ux + uy * uy;
+                if r2 <= EPSILON * EPSILON {
                     *degenerate = true;
                     return;
                 }
 
-                // Then calculate the partial derivatives.
-                // Taken from SymPy, see ezpz-sympy.
-                let r0dax = ((bx - cx)
-                    * libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        7_f64 / 2.0,
-                    )
-                    - 2.0
-                        * (ax - cx)
-                        * ((ax - cx) * (bx - cx) + (ay - cy) * (by - cy))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    - d * (ax - cx)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::sin(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
-                let r0day = ((by - cy)
-                    * libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        7_f64 / 2.0,
-                    )
-                    - 2.0
-                        * (ay - cy)
-                        * ((ax - cx) * (bx - cx) + (ay - cy) * (by - cy))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    - d * (ay - cy)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::sin(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
-                let r0dbx = (ax - cx) * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0)).recip();
-                let r0dby = (ay - cy) * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0)).recip();
-                let r0dcx = (libm::pow(
-                    libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                    7_f64 / 2.0,
-                ) * (-ax - bx + 2.0 * cx)
-                    + 2.0
-                        * (ax - cx)
-                        * ((ax - cx) * (bx - cx) + (ay - cy) * (by - cy))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    + d * (ax - cx)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::sin(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
-                let r0dcy = (libm::pow(
-                    libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                    7_f64 / 2.0,
-                ) * (-ay - by + 2.0 * cy)
-                    + 2.0
-                        * (ay - cy)
-                        * ((ax - cx) * (bx - cx) + (ay - cy) * (by - cy))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    + d * (ay - cy)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::sin(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
+                // Partials of res = (b - c) - R(α)·(a - c) with α = d / r, r = |a - c|.
+                // Let Ru = R(α)·u; rotating Ru by dα yields (-Ruy, Rux), and
+                // ∂α/∂u = -d·u / r³. The shared factor below is k = d / r³.
+                let r = r2.sqrt();
+                let alpha = d / r;
+                let sa = libm::sin(alpha);
+                let ca = libm::cos(alpha);
+                let rux = ca * ux - sa * uy;
+                let ruy = sa * ux + ca * uy;
+                let k = d / (r2 * r);
+
+                // res0 = (bx - cx) - rux
+                let r0dax = -ca - ruy * ux * k;
+                let r0day = sa - ruy * uy * k;
+                let r0dbx = 1.0;
+                let r0dby = 0.0;
+                let r0dcx = -1.0 + ca + ruy * ux * k;
+                let r0dcy = -sa + ruy * uy * k;
+
+                // res1 = (by - cy) - ruy
+                let r1dax = -sa + rux * ux * k;
+                let r1day = -ca + rux * uy * k;
+                let r1dbx = 0.0;
+                let r1dby = 1.0;
+                let r1dcx = sa - rux * ux * k;
+                let r1dcy = -1.0 + ca - rux * uy * k;
+
                 row0.extend([
                     JacobianVar {
                         id: id_ax,
@@ -2188,101 +2127,6 @@ impl Constraint {
                         partial_derivative: r0dcy,
                     },
                 ]);
-                let r1dax = ((by - cy)
-                    * libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        7_f64 / 2.0,
-                    )
-                    - 2.0
-                        * (ax - cx)
-                        * ((ax - cx) * (by - cy) - (ay - cy) * (bx - cx))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    + d * (ax - cx)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::cos(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
-                let r1day = ((-bx + cx)
-                    * libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        7_f64 / 2.0,
-                    )
-                    - 2.0
-                        * (ay - cy)
-                        * ((ax - cx) * (by - cy) - (ay - cy) * (bx - cx))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    + d * (ay - cy)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::cos(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
-                let r1dbx =
-                    (-ay + cy) * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0)).recip();
-                let r1dby = (ax - cx) * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0)).recip();
-                let r1dcx = ((ay - by)
-                    * libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        7_f64 / 2.0,
-                    )
-                    + 2.0
-                        * (ax - cx)
-                        * ((ax - cx) * (by - cy) - (ay - cy) * (bx - cx))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    - d * (ax - cx)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::cos(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
-                let r1dcy = ((-ax + bx)
-                    * libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        7_f64 / 2.0,
-                    )
-                    + 2.0
-                        * (ay - cy)
-                        * ((ax - cx) * (by - cy) - (ay - cy) * (bx - cx))
-                        * libm::pow(
-                            libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                            5_f64 / 2.0,
-                        )
-                    - d * (ay - cy)
-                        * libm::pow(libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0), 3.0)
-                        * libm::cos(
-                            d * (libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0))
-                                .sqrt()
-                                .recip(),
-                        ))
-                    / libm::pow(
-                        libm::pow(ax - cx, 2.0) + libm::pow(ay - cy, 2.0),
-                        9_f64 / 2.0,
-                    );
                 row1.extend([
                     JacobianVar {
                         id: id_ax,

--- a/ezpz/src/lib.rs
+++ b/ezpz/src/lib.rs
@@ -289,7 +289,7 @@ fn solve_inner<A: Analysis>(
     };
 
     let mut unsatisfied: Vec<usize> = Vec::new();
-    let outcome = model.solve_gauss_newton(&mut values, config);
+    let outcome = model.solve_levenberg_marquardt(&mut values, config);
     warnings.extend(model.warnings.lock().unwrap().drain(..));
     let success = match outcome {
         Ok(o) => o,

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -14,10 +14,12 @@ mod newton;
 // May as well round up to the nearest power of 2.
 const NONZEROES_PER_ROW: usize = 8;
 
-// Tikhonov regularization configuration. Note that some texts use lambda^2 as their
-// scaling parameter, but it's a magic constant we have to tune either way so who cares.
+// Initial value of the Levenberg-Marquardt damping parameter λ. This is adapted
+// during the solve (scaled down on accepted steps, up on rejected ones), so it's
+// only a starting point. Some texts use lambda^2 as their scaling parameter, but
+// it's a magic constant we have to tune either way so who cares.
 // Ref: https://people.csail.mit.edu/jsolomon/share/book/numerical_book.pdf, 4.1.3
-const REGULARIZATION_LAMBDA: f64 = 1e-9;
+const DEFAULT_INITIAL_LAMBDA: f64 = 1e-9;
 
 /// Configuration for how to solve a system.
 /// ```
@@ -35,6 +37,8 @@ pub struct Config {
     convergence_tolerance: f64,
     /// Stop iterating if the step size becomes negligible (relative infinity norm).
     step_tolerance: f64,
+    /// Initial value of the Levenberg-Marquardt damping parameter λ.
+    initial_lambda: f64,
 }
 
 impl Config {
@@ -56,6 +60,12 @@ impl Config {
         self.step_tolerance = value;
         self
     }
+
+    /// Initial value of the Levenberg-Marquardt damping parameter λ.
+    pub fn with_initial_lambda(mut self, value: f64) -> Self {
+        self.initial_lambda = value;
+        self
+    }
 }
 
 impl Default for Config {
@@ -64,6 +74,7 @@ impl Default for Config {
             max_iterations: 35,
             convergence_tolerance: 1e-8,
             step_tolerance: 1e-12,
+            initial_lambda: DEFAULT_INITIAL_LAMBDA,
         }
     }
 }
@@ -123,7 +134,6 @@ pub(crate) struct Model<'c> {
     row1_scratch: Vec<JacobianVar>,
     row2_scratch: Vec<JacobianVar>,
     pub(crate) warnings: Mutex<Vec<Warning>>,
-    lambda_i: faer::sparse::SparseColMat<usize, f64>,
     lu_symbolic: SymbolicLu<usize>,
 }
 
@@ -247,17 +257,13 @@ impl<'c> Model<'c> {
             &nonzero_cells_j,
         )?;
 
-        // Preallocate this so we can use it whenever we run a newton solve.
-        // This 'damps' the jacobian matrix, ensuring that as its coefficients get smaller,
-        // the solver takes smaller and smaller steps.
-        let lambda_i = build_lambda_i(layout.num_variables);
-
         let jc = JacobianCache {
             vals: vec![0.0; sym.compute_nnz()], // We have a nonzero count util.
             sym,
         };
 
         // Precompute the symbolic LU of A = JᵀJ + λI so we can reuse it inside the Newton loop.
+        let lambda_i = build_lambda_i(layout.num_variables, config.initial_lambda);
         let lu_symbolic = Self::precompute_symbolic_lu(&jc.sym, &lambda_i)?;
 
         // All done.
@@ -269,7 +275,6 @@ impl<'c> Model<'c> {
             row0_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
             row1_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
             row2_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
-            lambda_i,
             lu_symbolic,
         })
     }
@@ -291,12 +296,12 @@ impl<'c> Model<'c> {
     }
 }
 
-fn build_lambda_i(num_variables: usize) -> faer::sparse::SparseColMat<usize, f64> {
+fn build_lambda_i(num_variables: usize, lambda: f64) -> faer::sparse::SparseColMat<usize, f64> {
     faer::sparse::SparseColMat::<usize, f64>::try_new_from_triplets(
         num_variables,
         num_variables,
         &(0..num_variables)
-            .map(|i| faer::sparse::Triplet::new(i, i, REGULARIZATION_LAMBDA))
+            .map(|i| faer::sparse::Triplet::new(i, i, lambda))
             .collect::<Vec<_>>(),
     )
     .unwrap()

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -34,7 +34,7 @@ pub struct Config {
     max_iterations: usize,
     /// How close can the residual be to 0 before we declare the system is solved?
     /// Smaller number means more precise solves.
-    convergence_tolerance: f64,
+    residual_tolerance: f64,
     /// Stop iterating if the step size becomes negligible (relative infinity norm).
     step_tolerance: f64,
     /// Initial value of the Levenberg-Marquardt damping parameter λ.
@@ -51,7 +51,7 @@ impl Config {
     /// How close can the residual be to 0 before we declare the system is solved?
     /// Smaller number means more precise solves.
     pub fn with_convergence_tolerance(mut self, value: f64) -> Self {
-        self.convergence_tolerance = value;
+        self.residual_tolerance = value;
         self
     }
 
@@ -72,7 +72,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             max_iterations: 35,
-            convergence_tolerance: 1e-8,
+            residual_tolerance: 1e-8,
             step_tolerance: 1e-12,
             initial_lambda: DEFAULT_INITIAL_LAMBDA,
         }

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -134,6 +134,7 @@ pub(crate) struct Model<'c> {
     row1_scratch: Vec<JacobianVar>,
     row2_scratch: Vec<JacobianVar>,
     pub(crate) warnings: Mutex<Vec<Warning>>,
+    lambda_i: faer::sparse::SparseColMat<usize, f64>,
     lu_symbolic: SymbolicLu<usize>,
 }
 
@@ -275,6 +276,7 @@ impl<'c> Model<'c> {
             row0_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
             row1_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
             row2_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
+            lambda_i,
             lu_symbolic,
         })
     }

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -6,7 +6,11 @@ use faer::{
 
 use crate::{Config, NonLinearSystemError};
 
-use super::Model;
+use super::{Model, build_lambda_i};
+
+// Levenberg-Marquardt adaptive damping params
+const LM_LAMBDA_INCR: f64 = 10.0;
+const LM_LAMBDA_DECR: f64 = 0.1;
 
 #[derive(Debug)]
 pub struct SuccessfulSolve {
@@ -24,16 +28,22 @@ impl Model<'_> {
         config: Config,
     ) -> Result<SuccessfulSolve, NonLinearSystemError> {
         let m = self.layout.total_num_residuals;
+        let n = current_values.len();
 
         let mut global_residual = vec![0.0; m];
+        let mut step = vec![0.0; n];
+
+        // NOTE(dr): We use a standard Levenberg-Marquardt adaptive damping scheme here where the
+        // damping parameter λ is scaled down on accepted steps and up on rejected ones. A step is
+        // rejected if it doesn't reduce the squared norm of the residual, which biases toward
+        // gradient descent (more stable) near singular configurations where Gauss-Newton
+        // overshoots.
+        let mut lambda = config.initial_lambda;
+
+        let mut residual_sq = self.eval(current_values, &mut global_residual);
+        let mut converged = false;
 
         for this_iteration in 0..config.max_iterations {
-            // Assemble global residual and Jacobian
-            // Re-evaluate the global residual.
-            self.residual(current_values, &mut global_residual);
-            // Re-evaluate the global jacobian, write it into self.jc
-            self.refresh_jacobian(current_values);
-
             // Convergence check: if the residual is within our tolerance,
             // then the system is totally solved and we can return.
             let largest_absolute_elem = global_residual
@@ -46,55 +56,86 @@ impl Model<'_> {
                     iterations: this_iteration,
                     converged: true,
                 });
-            }
-
-            /* NOTE(dr): We solve the following linear system to get the damped Gauss-Newton step d
-               (JᵀJ + λI) d = -Jᵀr
-               This involves creating a matrix A and rhs b where
-               A = JᵀJ + λI
-               b = -Jᵀr
-            */
-
-            let j =
-                SparseColMatRef::new(self.jacobian_cache.sym.as_ref(), &self.jacobian_cache.vals);
-            // TODO: Is there any way to transpose `j` and keep it in column-major?
-            // Converting from row- to column-major might not be necessary.
-            let jtj = j.transpose().to_col_major()? * j;
-            let a = jtj + &self.lambda_i;
-            let b = j.transpose() * -ColRef::from_slice(&global_residual);
-
-            // Solve linear system
-            let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
-            let d = factored.solve(&b);
-            assert_eq!(
-                d.nrows(),
-                current_values.len(),
-                "the `d` column must be the same size as the number of variables."
-            );
-            let current_inf_norm = current_values.iter().map(|v| v.abs()).fold(0.0, libm::fmax);
-            let step_inf_norm = d.iter().map(|d| d.abs()).reduce(libm::fmax).unwrap_or(0.0);
-            current_values
-                .iter_mut()
-                .zip(d.iter())
-                .for_each(|(curr_val, d)| {
-                    *curr_val += d;
-                });
-            let step_threshold = config.step_tolerance * (current_inf_norm + config.step_tolerance);
-
-            // Convergence check: if `d` is small enough,
-            // then the system is at a local minimum. It might be inconsistent, and therefore
-            // its residual will never get close to zero, but this is still a good least-squares solution,
-            // so we can return.
-            if step_inf_norm <= step_threshold {
+            } else if converged {
+                // The step shrank below tolerance without zeroing the residual indicating a
+                // least-squares solution
                 return Ok(SuccessfulSolve {
                     iterations: this_iteration,
                     converged: true,
                 });
             }
+
+            /*
+                NOTE(dr): We solve the following linear system to get the damped Gauss-Newton step d
+
+                    (JᵀJ + λI) d = -Jᵀr
+
+                This involves creating a matrix A and rhs b where
+
+                    A = JᵀJ + λI
+                    b = -Jᵀr
+            */
+
+            let step_inf_norm = {
+                let j = SparseColMatRef::new(
+                    self.jacobian_cache.sym.as_ref(),
+                    &self.jacobian_cache.vals,
+                );
+                // TODO: Is there any way to transpose `j` and keep it in column-major?
+                // Converting from row- to column-major might not be necessary.
+                let jtj = j.transpose().to_col_major()? * j;
+                let lambda_i = build_lambda_i(n, lambda);
+                let a = jtj + &lambda_i;
+                let b = j.transpose() * -ColRef::from_slice(&global_residual);
+
+                // Solve linear system
+                let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
+                let d = factored.solve(&b);
+                assert_eq!(
+                    d.nrows(),
+                    n,
+                    "the `d` column must be the same size as the number of variables."
+                );
+                step.iter_mut().zip(d.iter()).for_each(|(s, d)| *s = *d);
+                d.iter().map(|d| d.abs()).reduce(libm::fmax).unwrap_or(0.0)
+            };
+
+            // Take the tentative step and re-evaluate at the new position.
+            current_values
+                .iter_mut()
+                .zip(step.iter())
+                .for_each(|(curr_val, d)| *curr_val += d);
+            let residual_sq_new = self.eval(current_values, &mut global_residual);
+
+            if residual_sq_new < residual_sq {
+                // Step reduced the residual: accept it and decrease λ.
+                lambda *= LM_LAMBDA_DECR;
+                residual_sq = residual_sq_new;
+            } else {
+                // Step didn't reduce the residual: revert it, restore the residual and Jacobian to
+                // the old position, and increase λ.
+                current_values
+                    .iter_mut()
+                    .zip(step.iter())
+                    .for_each(|(curr_val, d)| *curr_val -= d);
+                residual_sq = self.eval(current_values, &mut global_residual);
+                lambda *= LM_LAMBDA_INCR;
+            }
+
+            // Flag as converged if the step was negligibly small (even if it wasn't taken)
+            converged = step_inf_norm <= config.step_tolerance;
         }
         Ok(SuccessfulSolve {
             iterations: config.max_iterations,
             converged: false,
         })
+    }
+
+    /// Re-evaluate the global residual and Jacobian at `current_values`, returning the
+    /// squared norm of the residual.
+    fn eval(&mut self, current_values: &[f64], global_residual: &mut [f64]) -> f64 {
+        self.residual(current_values, global_residual);
+        self.refresh_jacobian(current_values);
+        global_residual.iter().map(|x| x * x).sum()
     }
 }

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -36,8 +36,7 @@ impl Model<'_> {
         // NOTE(dr): We use a standard Levenberg-Marquardt adaptive damping scheme here where the
         // damping parameter λ is scaled down on accepted steps and up on rejected ones. A step is
         // rejected if it doesn't reduce the squared norm of the residual, which biases toward
-        // gradient descent (more stable) near singular configurations where Gauss-Newton
-        // overshoots.
+        // gradient descent near singular configurations where Gauss-Newton tends to overshoot.
         let mut lambda = config.initial_lambda;
 
         let mut residual_sq = self.eval(current_values, &mut global_residual);

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -31,6 +31,7 @@ impl Model<'_> {
         let n = current_values.len();
 
         let mut global_residual = vec![0.0; m];
+        let mut tentative_residual = vec![0.0; m];
         let mut step = vec![0.0; n];
 
         // NOTE(dr): We use a standard Levenberg-Marquardt adaptive damping scheme here where the
@@ -99,25 +100,26 @@ impl Model<'_> {
                 d.iter().map(|d| d.abs()).reduce(libm::fmax).unwrap_or(0.0)
             };
 
-            // Take the tentative step and re-evaluate at the new position.
+            // Take the tentative step and evaluate the residual at the new position
             current_values
                 .iter_mut()
                 .zip(step.iter())
                 .for_each(|(curr_val, d)| *curr_val += d);
-            let residual_sq_new = self.eval(current_values, &mut global_residual);
+            self.residual(current_values, &mut tentative_residual);
+            let residual_sq_new: f64 = tentative_residual.iter().map(|x| x * x).sum();
 
             if residual_sq_new < residual_sq {
                 // Step reduced the residual: accept it and decrease λ.
-                lambda *= LM_LAMBDA_DECR;
+                std::mem::swap(&mut global_residual, &mut tentative_residual);
+                self.refresh_jacobian(current_values);
                 residual_sq = residual_sq_new;
+                lambda *= LM_LAMBDA_DECR;
             } else {
-                // Step didn't reduce the residual: revert it, restore the residual and Jacobian to
-                // the old position, and increase λ.
+                // Step didn't reduce the residual: revert it and increase λ.
                 current_values
                     .iter_mut()
                     .zip(step.iter())
                     .for_each(|(curr_val, d)| *curr_val -= d);
-                residual_sq = self.eval(current_values, &mut global_residual);
                 lambda *= LM_LAMBDA_INCR;
             }
 

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -6,7 +6,7 @@ use faer::{
 
 use crate::{Config, NonLinearSystemError};
 
-use super::{Model, build_lambda_i};
+use super::Model;
 
 // Levenberg-Marquardt adaptive damping params
 const LM_LAMBDA_INCR: f64 = 10.0;
@@ -21,8 +21,9 @@ pub struct SuccessfulSolve {
 }
 
 impl Model<'_> {
+    /// Solve via Levenberg-Marquardt algorithm (Gauss-Newton with adaptive damping)
     #[inline(never)]
-    pub(crate) fn solve_gauss_newton(
+    pub(crate) fn solve_levenberg_marquardt(
         &mut self,
         current_values: &mut [f64],
         config: Config,
@@ -31,17 +32,14 @@ impl Model<'_> {
         let n = current_values.len();
 
         let mut global_residual = vec![0.0; m];
-        let mut tentative_residual = vec![0.0; m];
-        let mut step = vec![0.0; n];
+        let mut next_residual = vec![0.0; m];
 
         // NOTE(dr): We use a standard Levenberg-Marquardt adaptive damping scheme here where the
         // damping parameter λ is scaled down on accepted steps and up on rejected ones. A step is
         // rejected if it doesn't reduce the squared norm of the residual, which biases toward
         // gradient descent near singular configurations where Gauss-Newton tends to overshoot.
         let mut lambda = config.initial_lambda;
-
         let mut residual_sq = self.eval(current_values, &mut global_residual);
-        let mut converged = false;
 
         for this_iteration in 0..config.max_iterations {
             // Convergence check: if the residual is within our tolerance,
@@ -52,13 +50,6 @@ impl Model<'_> {
                 .reduce(libm::fmax)
                 .ok_or(NonLinearSystemError::EmptySystemNotAllowed)?;
             if largest_absolute_elem <= config.residual_tolerance {
-                return Ok(SuccessfulSolve {
-                    iterations: this_iteration,
-                    converged: true,
-                });
-            } else if converged {
-                // The step shrank below tolerance without zeroing the residual indicating a
-                // least-squares solution
                 return Ok(SuccessfulSolve {
                     iterations: this_iteration,
                     converged: true,
@@ -76,55 +67,141 @@ impl Model<'_> {
                     b = -Jᵀr
             */
 
-            let step_inf_norm = {
-                let j = SparseColMatRef::new(
-                    self.jacobian_cache.sym.as_ref(),
-                    &self.jacobian_cache.vals,
-                );
-                // TODO: Is there any way to transpose `j` and keep it in column-major?
-                // Converting from row- to column-major might not be necessary.
-                let jtj = j.transpose().to_col_major()? * j;
-                let lambda_i = build_lambda_i(n, lambda);
-                let a = jtj + &lambda_i;
-                let b = j.transpose() * -ColRef::from_slice(&global_residual);
+            let j =
+                SparseColMatRef::new(self.jacobian_cache.sym.as_ref(), &self.jacobian_cache.vals);
+            // TODO: Is there any way to transpose `j` and keep it in column-major?
+            // Converting from row- to column-major might not be necessary.
+            let jtj = j.transpose().to_col_major()? * j;
 
-                // Solve linear system
-                let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
-                let d = factored.solve(&b);
-                assert_eq!(
-                    d.nrows(),
-                    n,
-                    "the `d` column must be the same size as the number of variables."
-                );
-                step.iter_mut().zip(d.iter()).for_each(|(s, d)| *s = *d);
-                d.iter().map(|d| d.abs()).reduce(libm::fmax).unwrap_or(0.0)
-            };
+            // Update λI with current damping value
+            self.lambda_i.val_mut().fill(lambda);
+
+            // Solve linear system
+            let a = jtj + &self.lambda_i;
+            let b = j.transpose() * -ColRef::from_slice(&global_residual);
+
+            // Solve the linear system for the step `d`.
+            let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
+            let d = factored.solve(&b);
+            assert_eq!(
+                d.nrows(),
+                n,
+                "the `d` column must be the same size as the number of variables."
+            );
+            let step_inf_norm = d.iter().map(|x| x.abs()).reduce(libm::fmax).unwrap_or(0.0);
 
             // Take the tentative step and evaluate the residual at the new position
             current_values
                 .iter_mut()
-                .zip(step.iter())
-                .for_each(|(curr_val, d)| *curr_val += d);
-            self.residual(current_values, &mut tentative_residual);
-            let residual_sq_new: f64 = tentative_residual.iter().map(|x| x * x).sum();
+                .zip(d.iter())
+                .for_each(|(curr_val, step)| *curr_val += step);
+            self.residual(current_values, &mut next_residual);
+            let next_residual_sq: f64 = next_residual.iter().map(|x| x * x).sum();
 
-            if residual_sq_new < residual_sq {
+            if next_residual_sq < residual_sq {
                 // Step reduced the residual: accept it and decrease λ.
-                std::mem::swap(&mut global_residual, &mut tentative_residual);
+                std::mem::swap(&mut global_residual, &mut next_residual);
                 self.refresh_jacobian(current_values);
-                residual_sq = residual_sq_new;
+                residual_sq = next_residual_sq;
                 lambda *= LM_LAMBDA_DECR;
             } else {
                 // Step didn't reduce the residual: revert it and increase λ.
                 current_values
                     .iter_mut()
-                    .zip(step.iter())
-                    .for_each(|(curr_val, d)| *curr_val -= d);
+                    .zip(d.iter())
+                    .for_each(|(curr_val, step)| *curr_val -= step);
                 lambda *= LM_LAMBDA_INCR;
             }
 
-            // Flag as converged if the step was negligibly small (even if it wasn't taken)
-            converged = step_inf_norm <= config.step_tolerance;
+            // Also need to check step size to identify convergence in the overconstrained case
+            if step_inf_norm <= config.step_tolerance {
+                return Ok(SuccessfulSolve {
+                    iterations: this_iteration,
+                    converged: true,
+                });
+            }
+        }
+        Ok(SuccessfulSolve {
+            iterations: config.max_iterations,
+            converged: false,
+        })
+    }
+
+    /// Solve via damped Gauss-Newton algorithm (retained for reference)
+    #[allow(dead_code)]
+    #[inline(never)]
+    pub(crate) fn solve_gauss_newton(
+        &mut self,
+        current_values: &mut [f64],
+        config: Config,
+    ) -> Result<SuccessfulSolve, NonLinearSystemError> {
+        let m = self.layout.total_num_residuals;
+        let n = current_values.len();
+
+        let mut global_residual = vec![0.0; m];
+
+        for this_iteration in 0..config.max_iterations {
+            // Assemble global residual and Jacobian
+            // Re-evaluate the global residual.
+            self.residual(current_values, &mut global_residual);
+            // Re-evaluate the global jacobian, write it into self.jc
+            self.refresh_jacobian(current_values);
+
+            // Convergence check: if the residual is within our tolerance,
+            // then the system is totally solved and we can return.
+            let largest_absolute_elem = global_residual
+                .iter()
+                .map(|x| x.abs())
+                .reduce(libm::fmax)
+                .ok_or(NonLinearSystemError::EmptySystemNotAllowed)?;
+            if largest_absolute_elem <= config.residual_tolerance {
+                return Ok(SuccessfulSolve {
+                    iterations: this_iteration,
+                    converged: true,
+                });
+            }
+
+            /* NOTE(dr): We solve the following linear system to get the damped Gauss-Newton step d
+               (JᵀJ + λI) d = -Jᵀr
+               This involves creating a matrix A and rhs b where
+               A = JᵀJ + λI
+               b = -Jᵀr
+            */
+
+            let j =
+                SparseColMatRef::new(self.jacobian_cache.sym.as_ref(), &self.jacobian_cache.vals);
+            // TODO: Is there any way to transpose `j` and keep it in column-major?
+            // Converting from row- to column-major might not be necessary.
+            let jtj = j.transpose().to_col_major()? * j;
+            let a = jtj + &self.lambda_i;
+            let b = j.transpose() * -ColRef::from_slice(&global_residual);
+
+            // Solve linear system
+            let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
+            let d = factored.solve(&b);
+            assert_eq!(
+                d.nrows(),
+                n,
+                "the `d` column must be the same size as the number of variables."
+            );
+            let step_inf_norm = d.iter().map(|d| d.abs()).reduce(libm::fmax).unwrap_or(0.0);
+            current_values
+                .iter_mut()
+                .zip(d.iter())
+                .for_each(|(curr_val, d)| {
+                    *curr_val += d;
+                });
+
+            // Convergence check: if `d` is small enough,
+            // then the system is at a local minimum. It might be inconsistent, and therefore
+            // its residual will never get close to zero, but this is still a good least-squares solution,
+            // so we can return.
+            if step_inf_norm <= config.step_tolerance {
+                return Ok(SuccessfulSolve {
+                    iterations: this_iteration,
+                    converged: true,
+                });
+            }
         }
         Ok(SuccessfulSolve {
             iterations: config.max_iterations,

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -51,7 +51,7 @@ impl Model<'_> {
                 .map(|x| x.abs())
                 .reduce(libm::fmax)
                 .ok_or(NonLinearSystemError::EmptySystemNotAllowed)?;
-            if largest_absolute_elem <= config.convergence_tolerance {
+            if largest_absolute_elem <= config.residual_tolerance {
                 return Ok(SuccessfulSolve {
                     iterations: this_iteration,
                     converged: true,

--- a/ezpz/src/tests.rs
+++ b/ezpz/src/tests.rs
@@ -1546,22 +1546,22 @@ fn lines_at_angle_isolated() {
         TestCase {
             points: [[0.0, 0.0], [1.0, 0.0], [0.0, 0.0], [0.0, 2.0]],
             angle: 0.0,
-            expected_iters: 3,
+            expected_iters: 4,
         },
         TestCase {
             points: [[0.0, 0.0], [1.0, 0.0], [0.0, 0.0], [0.0, 2.0]],
             angle: PI,
-            expected_iters: 3,
+            expected_iters: 4,
         },
         TestCase {
             points: [[0.0, 0.0], [0.0, 1.0], [0.0, 0.0], [0.0, 2.0]],
             angle: 0.5 * PI,
-            expected_iters: 3,
+            expected_iters: 4,
         },
         TestCase {
             points: [[0.0, 0.0], [0.0, 1.0], [0.0, 0.0], [0.0, 2.0]],
             angle: -0.5 * PI,
-            expected_iters: 3,
+            expected_iters: 4,
         },
     ];
 
@@ -1620,12 +1620,12 @@ fn lines_angle_sign_check() {
         TestCase {
             vars: [[0.0, 0.0], [1.0, 0.0], [2.0, 1.0]],
             angle: 0.1 * PI,
-            expected_iters: 1,
+            expected_iters: 3,
         },
         TestCase {
             vars: [[0.0, 0.0], [1.0, 0.0], [2.0, 1.0]],
             angle: -0.1 * PI,
-            expected_iters: 1,
+            expected_iters: 4,
         },
     ];
 

--- a/ezpz/src/tests/proptests.rs
+++ b/ezpz/src/tests/proptests.rs
@@ -626,38 +626,6 @@ proptest! {
     }
 
     #[test]
-    fn distance_var_analytic_jacobian_matches_finite_difference(
-        px in -100.0..100.0f64,
-        py in -100.0..100.0f64,
-        qx in -100.0..100.0f64,
-        qy in -100.0..100.0f64,
-        d in -100.0..100.0f64,
-    ) {
-        // Keep away from singular point-point distance where derivative wrt point coordinates is undefined.
-        prop_assume!(libm::hypot(px - qx, py - qy) > 1e-2);
-
-        let (constraint, layout, values, p, q, dist) =
-            make_distance_var_constraint(px, py, qx, qy, d);
-        let (row0, degenerate) = distance_var_jacobian(&constraint, &layout, &values);
-        prop_assert!(!degenerate, "this case should be non-degenerate");
-
-        let vars = [p.id_x(), p.id_y(), q.id_x(), q.id_y(), dist.id];
-        for var in vars {
-            let Some(analytic) = find_partial_derivative(&row0, var) else {
-                prop_assert!(false, "missing analytic partial derivative for id {var}");
-                continue;
-            };
-            let numeric = central_difference_derivative(&constraint, &layout, &values, var);
-            let tolerance = 1e-6 + 1e-4 * libm::fmax(analytic.abs(), numeric.abs());
-            let err = (analytic - numeric).abs();
-            prop_assert!(
-                err <= tolerance,
-                "id={var}: analytic={analytic}, numeric={numeric}, err={err}, tol={tolerance}"
-            );
-        }
-    }
-
-    #[test]
     fn distance_var_is_symmetric_under_point_swap(
         px in -100.0..100.0f64,
         py in -100.0..100.0f64,
@@ -847,35 +815,6 @@ fn find_partial_derivative(jacobian_row: &[JacobianVar], id: Id) -> Option<f64> 
 
 fn find_partial_derivative_or_zero(jacobian_row: &[JacobianVar], id: Id) -> f64 {
     find_partial_derivative(jacobian_row, id).unwrap_or(0.0)
-}
-
-fn central_difference_derivative(
-    constraint: &Constraint,
-    layout: &Layout,
-    values: &[f64],
-    var: Id,
-) -> f64 {
-    let index = layout.index_of(var);
-    let step = 1e-6 * (1.0 + values[index].abs());
-
-    let mut plus_values = values.to_vec();
-    plus_values[index] += step;
-    let (plus_residual, plus_degenerate) = distance_var_residual(constraint, layout, &plus_values);
-    assert!(
-        !plus_degenerate,
-        "finite-difference +step should not be degenerate for id {var}"
-    );
-
-    let mut minus_values = values.to_vec();
-    minus_values[index] -= step;
-    let (minus_residual, minus_degenerate) =
-        distance_var_residual(constraint, layout, &minus_values);
-    assert!(
-        !minus_degenerate,
-        "finite-difference -step should not be degenerate for id {var}"
-    );
-
-    (plus_residual - minus_residual) / (2.0 * step)
 }
 
 /// Given an arc, and a randomly-chosen percentage of the circle, constraint the arc

--- a/ezpz/src/tests/proptests.rs
+++ b/ezpz/src/tests/proptests.rs
@@ -132,8 +132,31 @@ fn arb_constraint() -> BoxedStrategy<Constraint> {
             .prop_map(|(arc, point)| Constraint::PointArcCoincident(arc, point)),
         (arb_arc(), arb_scalar()).prop_map(|(arc, dist)| Constraint::ArcLength(arc, dist)),
         (arb_arc(), arb_angle()).prop_map(|(arc, angle)| Constraint::ArcAngle(arc, angle)),
+        (arb_point(), arb_point(), arb_point(), arb_angle_kind())
+            .prop_map(|(p0, p1, p2, angle)| Constraint::PointsAtAngle(p0, p1, p2, angle)),
     ]
     .boxed()
+}
+
+/// Returns a copy of the constraint with every length-valued *constant* target scaled by `k`. Used
+/// to rescale a whole constraint instance to the same shape at a different model scale. Angle
+/// targets are dimensionless (unscaled); radii/distances supplied as solver variables scale via the
+/// assignment vector, not here.
+fn scale_constraint(c: &Constraint, k: f64) -> Constraint {
+    use Constraint::*;
+    match *c {
+        Distance(p0, p1, d) => Distance(p0, p1, d * k),
+        VerticalDistance(p0, p1, d) => VerticalDistance(p0, p1, d * k),
+        HorizontalDistance(p0, p1, d) => HorizontalDistance(p0, p1, d * k),
+        Fixed(id, v) => Fixed(id, v * k),
+        CircleRadius(circle, r) => CircleRadius(circle, r * k),
+        ArcRadius(arc, r) => ArcRadius(arc, r * k),
+        ArcLength(arc, d) => ArcLength(arc, d * k),
+        PointLineDistance(p, l, d) => PointLineDistance(p, l, d * k),
+        VerticalPointLineDistance(p, l, d) => VerticalPointLineDistance(p, l, d * k),
+        HorizontalPointLineDistance(p, l, d) => HorizontalPointLineDistance(p, l, d * k),
+        other => other,
+    }
 }
 
 proptest! {
@@ -205,6 +228,64 @@ proptest! {
                     component,
                     var,
                     (analytic - numeric).abs(),
+                );
+            }
+        }
+    }
+
+    /// Every constraint residual must be homogeneous of degree 1 in its variables (length units),
+    /// so the assembled least-squares system is uniformly scaled and well conditioned regardless of
+    /// model size. We can't assert that directly since constraints with a constant target aren't
+    /// homogeneous (e.g. `|p0 - p1| - d` has an additive constant), so we assert the equivalent
+    /// invariant on the gradient: a degree-1-homogeneous variable part has a degree-0
+    /// (scale-invariant) Jacobian. Rescaling the whole problem (variables and length-valued
+    /// targets) by `k` must leave every Jacobian entry unchanged.
+    #[test]
+    fn residual_jacobian_is_scale_invariant(
+        constraint in arb_constraint(),
+        raw_vals in proptest::collection::vec(-8.0f64..8.0, 32),
+    ) {
+        let mut ids = Vec::with_capacity(16);
+        constraint.extend_dependent_variable_ids(&mut ids);
+        let n = ids.iter().map(|id| *id as usize + 1).max().unwrap_or(0);
+        prop_assume!(n > 0 && n <= raw_vals.len());
+
+        let vals = raw_vals[..n].to_vec();
+        let layout = Layout::new(
+            &(0..n as Id).collect::<Vec<_>>(),
+            &[&constraint],
+            Config::default(),
+        );
+
+        let jac = |c: &Constraint, v: &[f64]| {
+            let (mut r0, mut r1, mut r2) = (Vec::new(), Vec::new(), Vec::new());
+            let mut degenerate = false;
+            c.jacobian_rows(&layout, v, &mut r0, &mut r1, &mut r2, &mut degenerate);
+            (r0, r1, r2, degenerate)
+        };
+
+        let (a0, a1, a2, deg_a) = jac(&constraint, &vals);
+        prop_assume!(!deg_a);
+
+        // Rescale the whole problem to the same shape at a different model scale.
+        let k = 8.0;
+        let scaled_vals: Vec<f64> = vals.iter().map(|v| v * k).collect();
+        let scaled_constraint = scale_constraint(&constraint, k);
+        let (b0, b1, b2, deg_b) = jac(&scaled_constraint, &scaled_vals);
+        prop_assume!(!deg_b);
+
+        for (row, (orig, scaled)) in [(&a0, &b0), (&a1, &b1), (&a2, &b2)].into_iter().enumerate() {
+            prop_assert_eq!(orig.len(), scaled.len(), "row {} sparsity changed under scaling", row);
+            for (jo, js) in orig.iter().zip(scaled.iter()) {
+                prop_assert_eq!(jo.id, js.id);
+                prop_assume!(jo.partial_derivative.is_finite() && js.partial_derivative.is_finite());
+                let (po, ps) = (jo.partial_derivative, js.partial_derivative);
+                let tol = 1e-6 * (1.0 + po.abs().max(ps.abs()));
+                prop_assert!(
+                    (po - ps).abs() <= tol,
+                    "{} Jacobian not scale-invariant (∂/∂id {}): {} at scale 1 vs {} at scale {} \
+                     - residual is not homogeneous degree 1",
+                    constraint.constraint_kind(), jo.id, po, ps, k,
                 );
             }
         }
@@ -835,8 +916,7 @@ fn test_point_arc_length(
     ];
 
     let requests: Vec<_> = vec![
-        // Fix the arc in place.
-        Constraint::Arc(arc),
+        // Pin the center and start in place
         Constraint::Fixed(arc.center.id_x(), arc_center_x),
         Constraint::Fixed(arc.center.id_y(), arc_center_y),
         Constraint::Fixed(arc.start.id_x(), arc_start.x),

--- a/ezpz/src/tests/proptests.rs
+++ b/ezpz/src/tests/proptests.rs
@@ -626,6 +626,38 @@ proptest! {
     }
 
     #[test]
+    fn distance_var_analytic_jacobian_matches_finite_difference(
+        px in -100.0..100.0f64,
+        py in -100.0..100.0f64,
+        qx in -100.0..100.0f64,
+        qy in -100.0..100.0f64,
+        d in -100.0..100.0f64,
+    ) {
+        // Keep away from singular point-point distance where derivative wrt point coordinates is undefined.
+        prop_assume!(libm::hypot(px - qx, py - qy) > 1e-2);
+
+        let (constraint, layout, values, p, q, dist) =
+            make_distance_var_constraint(px, py, qx, qy, d);
+        let (row0, degenerate) = distance_var_jacobian(&constraint, &layout, &values);
+        prop_assert!(!degenerate, "this case should be non-degenerate");
+
+        let vars = [p.id_x(), p.id_y(), q.id_x(), q.id_y(), dist.id];
+        for var in vars {
+            let Some(analytic) = find_partial_derivative(&row0, var) else {
+                prop_assert!(false, "missing analytic partial derivative for id {var}");
+                continue;
+            };
+            let numeric = central_difference_derivative(&constraint, &layout, &values, var);
+            let tolerance = 1e-6 + 1e-4 * libm::fmax(analytic.abs(), numeric.abs());
+            let err = (analytic - numeric).abs();
+            prop_assert!(
+                err <= tolerance,
+                "id={var}: analytic={analytic}, numeric={numeric}, err={err}, tol={tolerance}"
+            );
+        }
+    }
+
+    #[test]
     fn distance_var_is_symmetric_under_point_swap(
         px in -100.0..100.0f64,
         py in -100.0..100.0f64,
@@ -815,6 +847,35 @@ fn find_partial_derivative(jacobian_row: &[JacobianVar], id: Id) -> Option<f64> 
 
 fn find_partial_derivative_or_zero(jacobian_row: &[JacobianVar], id: Id) -> f64 {
     find_partial_derivative(jacobian_row, id).unwrap_or(0.0)
+}
+
+fn central_difference_derivative(
+    constraint: &Constraint,
+    layout: &Layout,
+    values: &[f64],
+    var: Id,
+) -> f64 {
+    let index = layout.index_of(var);
+    let step = 1e-6 * (1.0 + values[index].abs());
+
+    let mut plus_values = values.to_vec();
+    plus_values[index] += step;
+    let (plus_residual, plus_degenerate) = distance_var_residual(constraint, layout, &plus_values);
+    assert!(
+        !plus_degenerate,
+        "finite-difference +step should not be degenerate for id {var}"
+    );
+
+    let mut minus_values = values.to_vec();
+    minus_values[index] -= step;
+    let (minus_residual, minus_degenerate) =
+        distance_var_residual(constraint, layout, &minus_values);
+    assert!(
+        !minus_degenerate,
+        "finite-difference -step should not be degenerate for id {var}"
+    );
+
+    (plus_residual - minus_residual) / (2.0 * step)
 }
 
 /// Given an arc, and a randomly-chosen percentage of the circle, constraint the arc


### PR DESCRIPTION
This PR contains two related solver-stability improvements ported over from the [R&D repo](https://github.com/KittyCAD/rnd-constraint-solver):

1. Residuals are reformulated to be scale-covariant (homogeneous degree 1)
2. Gauss-Newton (GN) step is replaced with an adaptive Levenberg-Marquardt (LM) scheme

These were initially intended to be in separate PRs but they turned out to be mutually dependent (details [below](#why-combine)).

## Motivation

### 1. Scale-covariant residuals

Ensures all constraint residuals scale linearly with the model, meaning that we get consistent behavior regardless of model scale/units. Because residuals now correspond to a geometric error (in length units), this also allows us to bring the tolerance used to detect convergence (`residual_tolerance`) in line with the tolerance used in downstream modeling commands which is critical for producing closed solids.

### 2. Adaptive damping

Plain Gauss-Newton can take large (potentially *uphill*) steps which can overshoot a nearby solution, making for frustrating/unintuitive UX (e.g. the sketch suddenly jumps from initial conditions to an unexpected configuration). We partially address this issue with a fixed damping parameter but its effectiveness will vary from one sketch to another as it depends on the system being solved.

Levenberg-Marquardt uses an _adaptive_ damping scheme for this reason - `λ` is adjusted over the course of the solve to ensure that each step taken *reduces* the residual (downhill progress only), avoiding the problem of overshooting and landing on a distant/unexpected solution (or not converging at all).

To demonstrate, here's an example where GN fails to converge - the fixed damping parameter is too small resulting in oscillation.

[linkage-gauss-newton-1.webm](https://github.com/user-attachments/assets/408b470e-91f9-4472-8eb2-11764b6a3509)

Here's the same sketch with LM - adaptive damping kicks in to avoid the oscillation and it's able to narrow in on the least-squares solution (doesn't quite get there due to low iteration cap).

[linkage-levenberg-marquardt-1.webm](https://github.com/user-attachments/assets/6aeb19c9-43ff-46ba-b25e-ad3cf44fcda3)

<h2 id="why-combine">Why combine?</h2>

The two changes ended up being mutually dependent so introducing either one on its own would cause regressions. I've tried to unpack this a bit below.

### Scale-covariance first

Making the angle residuals scale-covariant results in arm-length-scaled form whose Jacobian blows up as one of the arms collapses. With the always-accept Gauss-Newton solver, this drove different types of non-convergence in different test cases (e.g. the `square` case collapses, `perpendicular` overshoots) and no fixed damping parameter `λ` was found to be robust at both extremes. LM's adaptive damping scheme naturally regularizes this, so the scale-covariance change is only sound with the new solver in place.

### Adaptive damping first

Without scale-covariance in place, a system of non-uniformly-scaled residuals ends up being damped inconsistently which slows down far-start arc/angle test cases enough to exceed the default iteration cap. We could temporarily relax this on a test-by-test basis to get this change in first but this would be immediately reverted with the following scale-covariance changes.