### PR TITLE
Use Cholesky decomp instead of LU

### DIFF
--- a/ezpz/src/error.rs
+++ b/ezpz/src/error.rs
@@ -1,6 +1,6 @@
 use faer::{
     linalg::svd::SvdError,
-    sparse::{CreationError, FaerError, linalg::LuError},
+    sparse::{CreationError, FaerError, linalg::LltError},
 };
 
 use crate::Id;
@@ -75,7 +75,7 @@ pub enum NonLinearSystemError {
     FaerSolve {
         /// Underlying error.
         #[from]
-        error: LuError,
+        error: LltError,
     },
     /// Faer: could not decompose Jacobian.
     #[error("Something went wrong doing SVD in faer")]

--- a/ezpz/src/solver.rs
+++ b/ezpz/src/solver.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 
-use faer::sparse::{Pair, SparseColMatRef, SymbolicSparseColMat, linalg::solvers::SymbolicLu};
+use faer::Side;
+use faer::sparse::{Pair, SparseColMatRef, SymbolicSparseColMat, linalg::solvers::SymbolicLlt};
 
 use crate::{
     Constraint, ConstraintEntry, NonLinearSystemError, Warning, WarningContent,
@@ -135,7 +136,7 @@ pub(crate) struct Model<'c> {
     row2_scratch: Vec<JacobianVar>,
     pub(crate) warnings: Mutex<Vec<Warning>>,
     lambda_i: faer::sparse::SparseColMat<usize, f64>,
-    lu_symbolic: SymbolicLu<usize>,
+    llt_symbolic: SymbolicLlt<usize>,
 }
 
 fn validate_variables(
@@ -263,9 +264,10 @@ impl<'c> Model<'c> {
             sym,
         };
 
-        // Precompute the symbolic LU of A = JᵀJ + λI so we can reuse it inside the Newton loop.
+        // Precompute the symbolic Cholesky factorization of A = JᵀJ + λI so we can reuse it inside
+        // the Newton loop
         let lambda_i = build_lambda_i(layout.num_variables, config.initial_lambda);
-        let lu_symbolic = Self::precompute_symbolic_lu(&jc.sym, &lambda_i)?;
+        let llt_symbolic = Self::precompute_symbolic_cholesky(&jc.sym, &lambda_i)?;
 
         // All done.
         Ok(Self {
@@ -277,24 +279,24 @@ impl<'c> Model<'c> {
             row1_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
             row2_scratch: Vec::with_capacity(NONZEROES_PER_ROW),
             lambda_i,
-            lu_symbolic,
+            llt_symbolic,
         })
     }
 
     /// This is used in the core Newton solving, but it can be calculated entirely from
     /// the symbolic structure of the constraints. So let's do it here, before running
     /// the newton loop, to keep that loop fast.
-    fn precompute_symbolic_lu(
+    fn precompute_symbolic_cholesky(
         jc_sym: &SymbolicSparseColMat<usize>,
         lambda_i: &faer::sparse::SparseColMat<usize, f64>,
-    ) -> Result<SymbolicLu<usize>, NonLinearSystemError> {
+    ) -> Result<SymbolicLlt<usize>, NonLinearSystemError> {
         // Any non-zero values will do; we only care about the sparsity pattern of JᵀJ + λI.
         let ones = vec![1.0; jc_sym.compute_nnz()];
         let j = SparseColMatRef::new(jc_sym.as_ref(), &ones);
         let jt = j.transpose().to_col_major()?;
         let jtj = jt * j;
         let a = jtj + lambda_i;
-        Ok(SymbolicLu::try_new(a.symbolic())?)
+        Ok(SymbolicLlt::try_new(a.symbolic(), Side::Lower)?)
     }
 }
 

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -1,7 +1,7 @@
 use faer::{
-    ColRef,
+    ColRef, Side,
     prelude::Solve,
-    sparse::{SparseColMatRef, linalg::solvers::Lu},
+    sparse::{SparseColMatRef, linalg::solvers::Llt},
 };
 
 use crate::{Config, NonLinearSystemError};
@@ -80,8 +80,9 @@ impl Model<'_> {
             let a = jtj + &self.lambda_i;
             let b = j.transpose() * -ColRef::from_slice(&global_residual);
 
-            // Solve the linear system for the step `d`.
-            let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
+            // Solve the linear system for the step `d`
+            let factored =
+                Llt::try_new_with_symbolic(self.llt_symbolic.clone(), a.as_ref(), Side::Lower)?;
             let d = factored.solve(&b);
             assert_eq!(
                 d.nrows(),
@@ -177,7 +178,8 @@ impl Model<'_> {
             let b = j.transpose() * -ColRef::from_slice(&global_residual);
 
             // Solve linear system
-            let factored = Lu::try_new_with_symbolic(self.lu_symbolic.clone(), a.as_ref())?;
+            let factored =
+                Llt::try_new_with_symbolic(self.llt_symbolic.clone(), a.as_ref(), Side::Lower)?;
             let d = factored.solve(&b);
             assert_eq!(
                 d.nrows(),

--- a/ezpz/src/solver/newton.rs
+++ b/ezpz/src/solver/newton.rs
@@ -1,7 +1,10 @@
 use faer::{
     ColRef, Side,
     prelude::Solve,
-    sparse::{SparseColMatRef, linalg::solvers::Llt},
+    sparse::{
+        SparseColMatRef,
+        linalg::{LltError, solvers::Llt},
+    },
 };
 
 use crate::{Config, NonLinearSystemError};
@@ -81,8 +84,21 @@ impl Model<'_> {
             let b = j.transpose() * -ColRef::from_slice(&global_residual);
 
             // Solve the linear system for the step `d`
-            let factored =
-                Llt::try_new_with_symbolic(self.llt_symbolic.clone(), a.as_ref(), Side::Lower)?;
+            let factored = match Llt::try_new_with_symbolic(
+                self.llt_symbolic.clone(),
+                a.as_ref(),
+                Side::Lower,
+            ) {
+                Ok(factored) => factored,
+                // A is SPD for λ > 0, so a numeric failure means λ has decayed enough that A is no
+                // longer numerically positive-definite. Treat it like a rejected step: increase λ
+                // and retry next iteration.
+                Err(LltError::Numeric(_)) => {
+                    lambda *= LM_LAMBDA_INCR;
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
             let d = factored.solve(&b);
             assert_eq!(
                 d.nrows(),


### PR DESCRIPTION
Improves solver performance by switching to a Cholesky decomposition for solving the sparse linear system at each step. This takes advantage of the fact that the system matrix $J^T J + \lambda I$ is guaranteed to be symmetric positive definite (SPD). The current LU decomposition is more general (accepts any square matrix) which also makes it more expensive (requires ~2x the operations and memory).